### PR TITLE
ユニオンレイド管理機能の実装

### DIFF
--- a/init.sql
+++ b/init.sql
@@ -37,6 +37,6 @@ CREATE TABLE IF NOT EXISTS raid_reports (
     UNIQUE(raid_id, user_id, difficulty)
 );
 
-CREATE INDEX idx_guild_id ON union_raids(guild_id);
-CREATE INDEX idx_raid_id ON raid_participants(raid_id);
-CREATE INDEX idx_user_id ON raid_participants(user_id);
+CREATE INDEX IF NOT EXISTS idx_guild_id ON union_raids(guild_id);
+CREATE INDEX IF NOT EXISTS idx_raid_id ON raid_participants(raid_id);
+CREATE INDEX IF NOT EXISTS idx_user_id ON raid_participants(user_id);

--- a/init.sql
+++ b/init.sql
@@ -12,7 +12,7 @@ CREATE TABLE IF NOT EXISTS union_raids (
     start_time TIMESTAMPTZ NOT NULL,
     end_time TIMESTAMPTZ NOT NULL,
     notify_time TIMESTAMPTZ,
-    channel_id BIGINT,
+    channel_id BIGINT NOT NULL,
     created_at TIMESTAMPTZ DEFAULT now()
 );
 

--- a/init.sql
+++ b/init.sql
@@ -1,16 +1,19 @@
 -- Initialize database schema
+
 CREATE TABLE IF NOT EXISTS guilds (
     guild_id BIGINT PRIMARY KEY,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    created_at TIMESTAMPTZ DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS union_raids (
     id SERIAL PRIMARY KEY,
     guild_id BIGINT REFERENCES guilds(guild_id) ON DELETE CASCADE,
     raid_name VARCHAR(255) NOT NULL,
-    start_time TIMESTAMP NOT NULL,
-    end_time TIMESTAMP NOT NULL,
-    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    start_time TIMESTAMPTZ NOT NULL,
+    end_time TIMESTAMPTZ NOT NULL,
+    notify_time TIMESTAMPTZ,
+    channel_id BIGINT,
+    created_at TIMESTAMPTZ DEFAULT now()
 );
 
 CREATE TABLE IF NOT EXISTS raid_participants (
@@ -19,8 +22,18 @@ CREATE TABLE IF NOT EXISTS raid_participants (
     user_id BIGINT NOT NULL,
     username VARCHAR(255) NOT NULL,
     score INTEGER DEFAULT 0,
-    joined_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    joined_at TIMESTAMPTZ DEFAULT now(),
     UNIQUE(raid_id, user_id)
+);
+
+CREATE TABLE IF NOT EXISTS raid_reports (
+    id SERIAL PRIMARY KEY,
+    raid_id INTEGER REFERENCES union_raids(id) ON DELETE CASCADE,
+    user_id BIGINT NOT NULL,
+    username VARCHAR(255) NOT NULL,
+    difficulty VARCHAR(32) NOT NULL,
+    is_3t INTEGER DEFAULT 0,
+    reported_at TIMESTAMPTZ DEFAULT now()
 );
 
 CREATE INDEX idx_guild_id ON union_raids(guild_id);

--- a/init.sql
+++ b/init.sql
@@ -33,7 +33,8 @@ CREATE TABLE IF NOT EXISTS raid_reports (
     username VARCHAR(255) NOT NULL,
     difficulty VARCHAR(32) NOT NULL,
     is_3t INTEGER DEFAULT 0,
-    reported_at TIMESTAMPTZ DEFAULT now()
+    reported_at TIMESTAMPTZ DEFAULT now(),
+    UNIQUE(raid_id, user_id, difficulty)
 );
 
 CREATE INDEX idx_guild_id ON union_raids(guild_id);

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,0 +1,75 @@
+import logging
+import asyncio
+import os
+import discord
+from discord.ext import commands
+from utils import utcnow_aware
+from database import async_session_factory, Base
+from sqlalchemy import delete
+from models import Guild
+from cogs.union_raid import UnionRaidCog
+
+logger = logging.getLogger(__name__)
+
+class NikkeUnionRaidBot(commands.Bot):
+    def __init__(self):
+        intents = discord.Intents.default()
+        intents.message_content = True
+        intents.guilds = True
+        intents.members = True
+        
+        super().__init__(
+            command_prefix="!",
+            intents=intents,
+            help_command=None
+        )
+    
+    async def setup_hook(self):
+        """Botの起動時に呼ばれる"""
+        # コマンドを登録
+        cog = UnionRaidCog(self)
+        await self.add_cog(cog)
+        
+        # Discordとコマンドを同期
+        logger.info("コマンドを同期しています...")
+        try:
+            # タイムアウト設定（20秒）
+            await asyncio.wait_for(self.tree.sync(), timeout=20.0)
+            logger.info("コマンドの同期が完了しました")
+        except Exception as e:
+            logger.warning(f"コマンド同期中にエラーが発生しました: {e}。Bot は継続して起動します。")
+        # resume schedules for pending raid notifications
+        try:
+            await cog.resume_schedules()
+        except Exception as e:
+            logger.error(f"スケジュール再開中にエラーが発生しました: {e}", exc_info=True)
+    
+    async def on_ready(self):
+        """Botの準備が完了したときに呼ばれる"""
+        logger.info(f'{self.user} (ID: {self.user.id}) としてログインしました')
+        logger.info(f'{len(self.guilds)}個のサーバーに接続しています')
+        
+        # Botのステータスを設定
+        await self.change_presence(
+            activity=discord.Game(name="NIKKE ユニオンレイド管理")
+        )
+    
+    async def on_guild_join(self, guild: discord.Guild):
+        """Botがサーバーに参加したときに呼ばれる"""
+        logger.info(f'サーバーに参加しました: {guild.name} (ID: {guild.id})')
+        
+        # データベースにサーバーを登録
+        async with async_session_factory() as session:
+            session.add(Guild(guild_id=guild.id))
+            await session.commit()
+    
+    async def on_guild_remove(self, guild: discord.Guild):
+        """Botがサーバーから退出したときに呼ばれる"""
+        logger.info(f'サーバーから退出しました: {guild.name} (ID: {guild.id})')
+        
+        # データベースからサーバーを削除
+        async with async_session_factory() as session:
+            await session.execute(
+                delete(Guild).where(Guild.guild_id == guild.id)
+            )
+            await session.commit()

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,10 +1,8 @@
 import logging
 import asyncio
-import os
 import discord
 from discord.ext import commands
-from utils import utcnow_aware
-from database import async_session_factory, Base
+from database import async_session_factory
 from sqlalchemy import delete
 from models import Guild
 from cogs.union_raid import UnionRaidCog

--- a/src/bot.py
+++ b/src/bot.py
@@ -1,11 +1,12 @@
 import logging
 import asyncio
 import discord
+from cogs.union_raid import UnionRaidCog
 from discord.ext import commands
 from database import async_session_factory
-from sqlalchemy import delete
 from models import Guild
-from cogs.union_raid import UnionRaidCog
+from sqlalchemy import delete
+from utils import utcnow_aware
 
 logger = logging.getLogger(__name__)
 
@@ -58,7 +59,7 @@ class NikkeUnionRaidBot(commands.Bot):
         
         # データベースにサーバーを登録
         async with async_session_factory() as session:
-            session.add(Guild(guild_id=guild.id))
+            session.add(Guild(guild_id=guild.id, created_at=utcnow_aware()))
             await session.commit()
     
     async def on_guild_remove(self, guild: discord.Guild):

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -1,18 +1,29 @@
 import logging
 import asyncio
+from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 import discord
 from discord import app_commands
 from discord.ext import commands
 from discord import ui
 from discord.ui import Modal, TextInput, View, Select, Button
-from typing import Dict
+from typing import Dict, Optional
 from database import async_session_factory
 from models import Guild, UnionRaid, RaidReport
 from utils import utcnow_aware, localnow_aware, DEFAULT_TIMEZONE, ensure_utc_aware
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
+
+@dataclass
+class RaidInfo:
+    id: int
+    guild_id: int
+    raid_name: str
+    start_time: datetime
+    end_time: datetime
+    notify_time: Optional[datetime]
+    channel_id: int
 
 class ReportView(View):
     def __init__(self):
@@ -79,20 +90,27 @@ class UnionRaidCog(commands.Cog):
             for row in rows:
                 # row is a SQLAlchemy RowMapping
                 data = dict(row._mapping)
-                # Build a lightweight raid-like object
-                class _R: pass
-                r = _R()
-                r.id = data.get('id')
-                r.guild_id = data.get('guild_id')
-                r.raid_name = data.get('raid_name')
-                r.start_time = ensure_utc_aware(data.get('start_time'))
-                r.end_time = ensure_utc_aware(data.get('end_time'))
-                r.notify_time = ensure_utc_aware(data.get('notify_time')) if data.get('notify_time') else None
-                r.channel_id = data.get('channel_id')
+                r = RaidInfo(
+                    id=data.get('id'),
+                    guild_id=data.get('guild_id'),
+                    raid_name=data.get('raid_name'),
+                    start_time=ensure_utc_aware(data.get('start_time')),
+                    end_time=ensure_utc_aware(data.get('end_time')),
+                    notify_time=ensure_utc_aware(data.get('notify_time')) if data.get('notify_time') else None,
+                    channel_id=data.get('channel_id'),
+                )
                 if r.notify_time and r.notify_time > now:
                     self._schedule_notification_task(r)
                 elif r.notify_time and r.notify_time <= now:
-                    r.notify_time = now
+                    r = RaidInfo(
+                        id=r.id,
+                        guild_id=r.guild_id,
+                        raid_name=r.raid_name,
+                        start_time=r.start_time,
+                        end_time=r.end_time,
+                        notify_time=now,
+                        channel_id=r.channel_id,
+                    )
                     self._schedule_notification_task(r)
     
     @app_commands.command(name="レイド作成", description="新しいユニオンレイドを作成します")
@@ -176,16 +194,15 @@ class UnionRaidCog(commands.Cog):
                         try:
                             cog: UnionRaidCog = interaction.client.get_cog('UnionRaidCog')
                             if cog:
-                                class _R: pass
-                                r = _R()
-                                r.id = raid.id
-                                r.guild_id = raid.guild_id
-                                r.raid_name = "ユニオンレイド"
-                                # pass aware times for scheduling/display
-                                r.start_time = start_time_aware
-                                r.end_time = end_time_aware
-                                r.notify_time = start_time_aware
-                                r.channel_id = raid.channel_id
+                                r = RaidInfo(
+                                    id=raid.id,
+                                    guild_id=raid.guild_id,
+                                    raid_name="ユニオンレイド",
+                                    start_time=start_time_aware,
+                                    end_time=end_time_aware,
+                                    notify_time=start_time_aware,
+                                    channel_id=raid.channel_id,
+                                )
                                 cog._schedule_notification_task(r)
                         except Exception:
                             logger.exception(f"レイド通知スケジュール中にエラー")
@@ -202,7 +219,7 @@ class UnionRaidCog(commands.Cog):
         modal = RaidStartModal()
         await interaction.response.send_modal(modal)
 
-    def _schedule_notification_task(self, raid: UnionRaid):
+    def _schedule_notification_task(self, raid: RaidInfo):
         """レイドの通知タスクを作成して管理辞書に登録する"""
         guild_id = raid.guild_id
         if guild_id in self._scheduled_tasks:

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -1,6 +1,5 @@
 import logging
 import asyncio
-import os
 from datetime import datetime, timedelta, timezone
 import discord
 from discord import app_commands
@@ -8,9 +7,8 @@ from discord.ext import commands
 from discord import ui
 from discord.ui import Modal, TextInput, View, Select, Button
 from typing import Dict
-from sqlalchemy import delete
 from database import async_session_factory
-from models import Guild, UnionRaid, RaidParticipant, RaidReport
+from models import Guild, UnionRaid, RaidReport
 from utils import utcnow_aware, localnow_aware, DEFAULT_TIMEZONE
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -9,139 +9,15 @@ from discord import ui
 from discord.ui import Modal, TextInput, View, Select, Button
 from typing import Dict
 from sqlalchemy import delete
-from database import async_session_factory, Base
-from sqlalchemy import Column, BigInteger, Integer, String, DateTime, ForeignKey
-from sqlalchemy.orm import relationship
+from database import async_session_factory
+from models import Guild, UnionRaid, RaidParticipant, RaidReport
+from utils import utcnow_aware, localnow_aware, DEFAULT_TIMEZONE
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
 
-# デフォルトタイムゾーン設定（環境変数 DEFAULT_TIMEZONE で変更可能、デフォルト: JST）
-DEFAULT_TIMEZONE_OFFSET = int(os.getenv('DEFAULT_TIMEZONE_HOURS', '9'))
-DEFAULT_TIMEZONE = timezone(timedelta(hours=DEFAULT_TIMEZONE_OFFSET))
-
-# ヘルパー: タイムゾーン情報付きの現在UTCと、DB保存用のナイーブUTCを返す
-def utcnow_aware() -> datetime:
-    return datetime.now(timezone.utc)
-
-def localnow_aware() -> datetime:
-    """デフォルトタイムゾーンでの現在時刻（aware）"""
-    return datetime.now(DEFAULT_TIMEZONE)
-
-# データベースモデル
-class Guild(Base):
-    __tablename__ = 'guilds'
-    
-    guild_id = Column(BigInteger, primary_key=True)
-    created_at = Column(DateTime(timezone=True), default=utcnow_aware)
-    
-    raids = relationship("UnionRaid", back_populates="guild", cascade="all, delete-orphan")
-
-class UnionRaid(Base):
-    __tablename__ = 'union_raids'
-    
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    guild_id = Column(BigInteger, ForeignKey('guilds.guild_id', ondelete='CASCADE'))
-    raid_name = Column(String(255), nullable=False)
-    start_time = Column(DateTime(timezone=True), nullable=False)
-    end_time = Column(DateTime(timezone=True), nullable=False)
-    notify_time = Column(DateTime(timezone=True), nullable=True)
-    channel_id = Column(BigInteger, nullable=True)
-    created_at = Column(DateTime(timezone=True), default=utcnow_aware)
-    
-    guild = relationship("Guild", back_populates="raids")
-    participants = relationship("RaidParticipant", back_populates="raid", cascade="all, delete-orphan")
-
-class RaidParticipant(Base):
-    __tablename__ = 'raid_participants'
-    
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    raid_id = Column(Integer, ForeignKey('union_raids.id', ondelete='CASCADE'))
-    user_id = Column(BigInteger, nullable=False)
-    username = Column(String(255), nullable=False)
-    score = Column(Integer, default=0)
-    joined_at = Column(DateTime(timezone=True), default=utcnow_aware)
-    
-    raid = relationship("UnionRaid", back_populates="participants")
-
-class RaidReport(Base):
-    __tablename__ = 'raid_reports'
-
-    id = Column(Integer, primary_key=True, autoincrement=True)
-    raid_id = Column(Integer, ForeignKey('union_raids.id', ondelete='CASCADE'))
-    user_id = Column(BigInteger, nullable=False)
-    username = Column(String(255), nullable=False)
-    difficulty = Column(String(32), nullable=False)  # 'normal' or 'hard'
-    is_3t = Column(Integer, default=0)  # 1 = true, 0 = false
-    reported_at = Column(DateTime(timezone=True), default=utcnow_aware)
-
-    raid = relationship("UnionRaid")
-
-class NikkeUnionRaidBot(commands.Bot):
-    def __init__(self):
-        intents = discord.Intents.default()
-        intents.message_content = True
-        intents.guilds = True
-        intents.members = True
-        
-        super().__init__(
-            command_prefix="!",
-            intents=intents,
-            help_command=None
-        )
-    
-    async def setup_hook(self):
-        """Botの起動時に呼ばれる"""
-        # コマンドを登録
-        cog = UnionRaidCog(self)
-        await self.add_cog(cog)
-        
-        # Discordとコマンドを同期
-        logger.info("コマンドを同期しています...")
-        try:
-            # タイムアウト設定（20秒）
-            await asyncio.wait_for(self.tree.sync(), timeout=20.0)
-            logger.info("コマンドの同期が完了しました")
-        except Exception as e:
-            logger.warning(f"コマンド同期中にエラーが発生しました: {e}。Bot は継続して起動します。")
-        # resume schedules for pending raid notifications
-        try:
-            await cog.resume_schedules()
-        except Exception as e:
-            logger.error(f"スケジュール再開中にエラーが発生しました: {e}", exc_info=True)
-    
-    async def on_ready(self):
-        """Botの準備が完了したときに呼ばれる"""
-        logger.info(f'{self.user} (ID: {self.user.id}) としてログインしました')
-        logger.info(f'{len(self.guilds)}個のサーバーに接続しています')
-        
-        # Botのステータスを設定
-        await self.change_presence(
-            activity=discord.Game(name="NIKKE ユニオンレイド管理")
-        )
-    
-    async def on_guild_join(self, guild: discord.Guild):
-        """Botがサーバーに参加したときに呼ばれる"""
-        logger.info(f'サーバーに参加しました: {guild.name} (ID: {guild.id})')
-        
-        # データベースにサーバーを登録
-        async with async_session_factory() as session:
-            session.add(Guild(guild_id=guild.id))
-            await session.commit()
-    
-    async def on_guild_remove(self, guild: discord.Guild):
-        """Botがサーバーから退出したときに呼ばれる"""
-        logger.info(f'サーバーから退出しました: {guild.name} (ID: {guild.id})')
-        
-        # データベースからサーバーを削除
-        async with async_session_factory() as session:
-            await session.execute(
-                delete(Guild).where(Guild.guild_id == guild.id)
-            )
-            await session.commit()
-
 class UnionRaidCog(commands.Cog):
-    def __init__(self, bot: NikkeUnionRaidBot):
+    def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._scheduled_tasks: Dict[int, asyncio.Task] = {}
 
@@ -419,5 +295,5 @@ class UnionRaidCog(commands.Cog):
             logger.error(f"レイド終了時にエラー: {e}")
             await interaction.followup.send(f"エラーが発生しました: {e}", ephemeral=True)
 
-async def setup(bot: NikkeUnionRaidBot):
+async def setup(bot):
     await bot.add_cog(UnionRaidCog(bot))

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -31,11 +31,17 @@ class ReportView(View):
 
     @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report")
     async def report_button(self, interaction: discord.Interaction, button: Button):
-        # embed から raid_id を取得
-        embed = interaction.message.embeds[0]
-        raid_id = int(embed.fields[1].value.strip('`'))
-        view = DifficultySelectView(raid_id)
-        await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
+        try:
+            # embed から raid_id を取得
+            embed = interaction.message.embeds[0]
+            raid_id = int(embed.fields[1].value.strip('`'))
+            view = DifficultySelectView(raid_id)
+            await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
+        except discord.errors.NotFound:
+            # インタラクショントークンの失効（ボット再起動後の古いメッセージ等）
+            logger.warning("report_button: Unknown interaction (token expired or already acknowledged)")
+        except Exception:
+            logger.exception("report_button でエラーが発生しました")
 
 
 class DifficultySelect(Select):

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -59,6 +59,10 @@ class UnionRaidCog(commands.Cog):
         期間時間: int = 24
     ):
         """レイド作成: モーダルで開始時刻を受け取る（通知は開始時刻と同じ）"""
+        if 期間時間 < 1:
+            await interaction.response.send_message("レイドの期間は1時間以上で指定してください。", ephemeral=True)
+            return
+
         class RaidStartModal(Modal, title="レイド開始設定"):
             def __init__(self):
                 super().__init__()

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -93,8 +93,6 @@ class UnionRaidCog(commands.Cog):
                                 created_at=utcnow_aware()
                             ).on_conflict_do_nothing(index_elements=['guild_id'])
                             await session.execute(stmt)
-                            # ensure we have the guild object afterwards
-                            guild = await session.get(Guild, interaction.guild_id)
 
                         now = utcnow_aware()
                         q = await session.execute(

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -34,42 +34,46 @@ class ReportView(View):
         # embed から raid_id を取得
         embed = interaction.message.embeds[0]
         raid_id = int(embed.fields[1].value.strip('`'))
-        # Modal を開く
-        modal = ReportModal(raid_id)
-        await interaction.response.send_modal(modal)
+        view = DifficultySelectView(raid_id)
+        await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
 
-class ReportModal(Modal):
+
+class DifficultySelect(Select):
     def __init__(self, raid_id: int):
-        super().__init__(title="レイド報告")
         self.raid_id = raid_id
-        self.difficulty = Select(
+        super().__init__(
             placeholder="難易度を選択してください",
             options=[
                 discord.SelectOption(label="ノーマル", value="normal"),
-                discord.SelectOption(label="ハード", value="hard")
+                discord.SelectOption(label="ハード", value="hard"),
             ]
         )
-        self.add_item(self.difficulty)
 
-    async def on_submit(self, modal_interaction: discord.Interaction):
-        difficulty = self.difficulty.values[0]
+    async def callback(self, interaction: discord.Interaction):
+        difficulty = self.values[0]
         async with async_session_factory() as session:
             q = await session.execute(
                 RaidReport.__table__.select().where(
-                    (RaidReport.raid_id == self.raid_id) & (RaidReport.user_id == modal_interaction.user.id) & (RaidReport.difficulty == difficulty)
+                    (RaidReport.raid_id == self.raid_id) & (RaidReport.user_id == interaction.user.id) & (RaidReport.difficulty == difficulty)
                 )
             )
             existing = q.first()
             if existing:
                 existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
                 await session.execute(
-                    RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_aware(), username=modal_interaction.user.display_name)
+                    RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_aware(), username=interaction.user.display_name)
                 )
             else:
-                report = RaidReport(raid_id=self.raid_id, user_id=modal_interaction.user.id, username=modal_interaction.user.display_name, difficulty=difficulty, is_3t=1)
+                report = RaidReport(raid_id=self.raid_id, user_id=interaction.user.id, username=interaction.user.display_name, difficulty=difficulty, is_3t=1)
                 session.add(report)
             await session.commit()
-        await modal_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
+        await interaction.response.send_message('報告を受け付けました。', ephemeral=True)
+
+
+class DifficultySelectView(View):
+    def __init__(self, raid_id: int):
+        super().__init__(timeout=60)
+        self.add_item(DifficultySelect(raid_id))
 
 class UnionRaidCog(commands.Cog):
     def __init__(self, bot: commands.Bot):

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -44,6 +44,9 @@ class UnionRaidCog(commands.Cog):
                 r.channel_id = data.get('channel_id')
                 if r.notify_time and r.notify_time > now:
                     self._schedule_notification_task(r)
+                elif r.notify_time and r.notify_time <= now:
+                    r.notify_time = now
+                    self._schedule_notification_task(r)
     
     @app_commands.command(name="レイド作成", description="新しいユニオンレイドを作成します")
     @app_commands.describe(

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -141,16 +141,16 @@ class UnionRaidCog(commands.Cog):
                                 r.channel_id = raid.channel_id
                                 cog._schedule_notification_task(r)
                         except Exception:
-                            logger.exception(f"レイド通知スケジュール中にエラー: {e}")
+                            logger.exception(f"レイド通知スケジュール中にエラー")
                             pass
-                except Exception as e:
-                    logger.exception(f"レイド作成モーダル処理中にエラー: {e}")
+                except Exception:
+                    logger.exception(f"レイド作成モーダル処理中にエラー")
                     try:
                         await modal_interaction.followup.send(f"入力の解析に失敗しました: {e}", ephemeral=True)
                     except discord.errors.NotFound:
                         logger.exception(f"モーダル例外メッセージ送信失敗（Unknown interaction）")
-                    except Exception as se:
-                        logger.error(f"例外送信時にさらにエラー: {se}")
+                    except Exception:
+                        logger.exception(f"例外送信時にさらにエラー")
 
         modal = RaidStartModal()
         await interaction.response.send_modal(modal)

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -25,7 +25,7 @@ class UnionRaidCog(commands.Cog):
         async with async_session_factory() as session:
             result = await session.execute(
                 UnionRaid.__table__.select().where(
-                    (UnionRaid.notify_time != None) & (UnionRaid.end_time > now)
+                    UnionRaid.notify_time.isnot(None) & (UnionRaid.end_time > now)
                 )
             )
             rows = result.fetchall()

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -141,6 +141,7 @@ class UnionRaidCog(commands.Cog):
                                 r.channel_id = raid.channel_id
                                 cog._schedule_notification_task(r)
                         except Exception:
+                            logger.exception(f"レイド通知スケジュール中にエラー: {e}")
                             pass
                 except Exception as e:
                     logger.exception(f"レイド作成モーダル処理中にエラー: {e}")

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -49,6 +49,7 @@ class UnionRaidCog(commands.Cog):
                     self._schedule_notification_task(r)
     
     @app_commands.command(name="レイド作成", description="新しいユニオンレイドを作成します")
+    @app_commands.guild_only()
     @app_commands.describe(
         期間時間="レイドの期間（時間単位、デフォルト: 24時間）"
     )
@@ -245,6 +246,7 @@ class UnionRaidCog(commands.Cog):
         self._scheduled_tasks[guild_id] = task
 
     @app_commands.command(name="レイド終了", description="進行中のレイドを終了し、3凸報告を集計します")
+    @app_commands.guild_only()
     async def raid_end(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=False)
         try:

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -14,10 +14,57 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
 
+class ReportView(View):
+    def __init__(self):
+        super().__init__(timeout=None)
+
+    @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report")
+    async def report_button(self, interaction: discord.Interaction, button: Button):
+        # embed から raid_id を取得
+        embed = interaction.message.embeds[0]
+        raid_id = int(embed.fields[1].value.strip('`'))
+        # Modal を開く
+        modal = ReportModal(raid_id)
+        await interaction.response.send_modal(modal)
+
+class ReportModal(Modal):
+    def __init__(self, raid_id: int):
+        super().__init__(title="レイド報告")
+        self.raid_id = raid_id
+        self.difficulty = Select(
+            placeholder="難易度を選択してください",
+            options=[
+                discord.SelectOption(label="ノーマル", value="normal"),
+                discord.SelectOption(label="ハード", value="hard")
+            ]
+        )
+        self.add_item(self.difficulty)
+
+    async def on_submit(self, modal_interaction: discord.Interaction):
+        difficulty = self.difficulty.values[0]
+        async with async_session_factory() as session:
+            q = await session.execute(
+                RaidReport.__table__.select().where(
+                    (RaidReport.raid_id == self.raid_id) & (RaidReport.user_id == modal_interaction.user.id) & (RaidReport.difficulty == difficulty)
+                )
+            )
+            existing = q.first()
+            if existing:
+                existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
+                await session.execute(
+                    RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_aware(), username=modal_interaction.user.display_name)
+                )
+            else:
+                report = RaidReport(raid_id=self.raid_id, user_id=modal_interaction.user.id, username=modal_interaction.user.display_name, difficulty=difficulty, is_3t=1)
+                session.add(report)
+            await session.commit()
+        await modal_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
+
 class UnionRaidCog(commands.Cog):
     def __init__(self, bot: commands.Bot):
         self.bot = bot
         self._scheduled_tasks: Dict[int, asyncio.Task] = {}
+        self.bot.add_view(ReportView())
 
     async def resume_schedules(self):
         """起動時にDBから残っているレイドを読み、通知をスケジュールする"""
@@ -143,7 +190,7 @@ class UnionRaidCog(commands.Cog):
                         except Exception:
                             logger.exception(f"レイド通知スケジュール中にエラー")
                             pass
-                except Exception:
+                except Exception as e:
                     logger.exception(f"レイド作成モーダル処理中にエラー")
                     try:
                         await modal_interaction.followup.send(f"入力の解析に失敗しました: {e}", ephemeral=True)
@@ -189,49 +236,7 @@ class UnionRaidCog(commands.Cog):
                     embed.add_field(name="開始時刻", value=f"<t:{int(ts_dt.timestamp())}:F>")
                     embed.add_field(name="レイドID", value=f"`{raid.id}`")
 
-                    class ReportView(View):
-                        def __init__(self, raid_id: int, timeout_seconds: float):
-                            super().__init__(timeout=timeout_seconds)
-                            self.raid_id = raid_id
-
-                        @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")
-                        async def report_button(self, interaction: discord.Interaction, button: Button):
-                            raid_id_ref = self.raid_id
-                            
-                            class DifficultySelect(Select):
-                                def __init__(self):
-                                    options = [
-                                        discord.SelectOption(label="ノーマル", value="normal"),
-                                        discord.SelectOption(label="ハード", value="hard")
-                                    ]
-                                    super().__init__(placeholder="難易度を選択してください", options=options)
-                                
-                                async def callback(self, select_interaction: discord.Interaction):
-                                    difficulty = self.values[0]
-                                    async with async_session_factory() as session:
-                                        q = await session.execute(
-                                            RaidReport.__table__.select().where(
-                                                (RaidReport.raid_id == raid_id_ref) & (RaidReport.user_id == select_interaction.user.id) & (RaidReport.difficulty == difficulty)
-                                            )
-                                        )
-                                        existing = q.first()
-                                        if existing:
-                                            existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
-                                            await session.execute(
-                                                RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_aware(), username=select_interaction.user.display_name)
-                                            )
-                                        else:
-                                            report = RaidReport(raid_id=raid_id_ref, user_id=select_interaction.user.id, username=select_interaction.user.display_name, difficulty=difficulty, is_3t=1)
-                                            session.add(report)
-                                        await session.commit()
-                                    await select_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
-                            
-                            view = View()
-                            view.add_item(DifficultySelect())
-                            await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
-
-                    timeout_seconds = (raid.end_time - utcnow_aware()).total_seconds()
-                    view = ReportView(raid_id=raid.id, timeout_seconds=timeout_seconds)
+                    view = ReportView()
                     await channel.send(embed=embed, view=view)
                     async with async_session_factory() as session:
                         await session.execute(

--- a/src/cogs/union_raid.py
+++ b/src/cogs/union_raid.py
@@ -9,7 +9,7 @@ from discord.ui import Modal, TextInput, View, Select, Button
 from typing import Dict
 from database import async_session_factory
 from models import Guild, UnionRaid, RaidReport
-from utils import utcnow_aware, localnow_aware, DEFAULT_TIMEZONE
+from utils import utcnow_aware, localnow_aware, DEFAULT_TIMEZONE, ensure_utc_aware
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
@@ -85,9 +85,9 @@ class UnionRaidCog(commands.Cog):
                 r.id = data.get('id')
                 r.guild_id = data.get('guild_id')
                 r.raid_name = data.get('raid_name')
-                r.start_time = data.get('start_time')
-                r.end_time = data.get('end_time')
-                r.notify_time = data.get('notify_time')
+                r.start_time = ensure_utc_aware(data.get('start_time'))
+                r.end_time = ensure_utc_aware(data.get('end_time'))
+                r.notify_time = ensure_utc_aware(data.get('notify_time')) if data.get('notify_time') else None
                 r.channel_id = data.get('channel_id')
                 if r.notify_time and r.notify_time > now:
                     self._schedule_notification_task(r)
@@ -126,9 +126,9 @@ class UnionRaidCog(commands.Cog):
                     start_time_local = datetime.strptime(start_text, "%Y-%m-%d %H:%M").replace(tzinfo=DEFAULT_TIMEZONE)
                     start_time_aware = start_time_local.astimezone(timezone.utc)
                     end_time_aware = start_time_aware + timedelta(hours=期間時間)
-                    # store naive UTC datetimes in DB to match existing schema
-                    start_time = start_time_aware.replace(tzinfo=None)
-                    end_time = end_time_aware.replace(tzinfo=None)
+                    # store aware UTC datetimes in DB
+                    start_time = start_time_aware
+                    end_time = end_time_aware
                     notify_time = start_time
 
                     async with async_session_factory() as session:

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -1,5 +1,6 @@
 import logging
 import asyncio
+import os
 from datetime import datetime, timedelta, timezone
 import discord
 from discord import app_commands
@@ -15,6 +16,10 @@ from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
 
+# デフォルトタイムゾーン設定（環境変数 DEFAULT_TIMEZONE で変更可能、デフォルト: JST）
+DEFAULT_TIMEZONE_OFFSET = int(os.getenv('DEFAULT_TIMEZONE_HOURS', '9'))
+DEFAULT_TIMEZONE = timezone(timedelta(hours=DEFAULT_TIMEZONE_OFFSET))
+
 # ヘルパー: タイムゾーン情報付きの現在UTCと、DB保存用のナイーブUTCを返す
 def utcnow_aware() -> datetime:
     return datetime.now(timezone.utc)
@@ -22,12 +27,16 @@ def utcnow_aware() -> datetime:
 def utcnow_naive() -> datetime:
     return datetime.now(timezone.utc).replace(tzinfo=None)
 
+def localnow_aware() -> datetime:
+    """デフォルトタイムゾーンでの現在時刻（aware）"""
+    return datetime.now(DEFAULT_TIMEZONE)
+
 # データベースモデル
 class Guild(Base):
     __tablename__ = 'guilds'
     
     guild_id = Column(BigInteger, primary_key=True)
-    created_at = Column(DateTime, default=lambda: utcnow_naive())
+    created_at = Column(DateTime(timezone=True), default=utcnow_aware)
     
     raids = relationship("UnionRaid", back_populates="guild", cascade="all, delete-orphan")
 
@@ -37,11 +46,11 @@ class UnionRaid(Base):
     id = Column(Integer, primary_key=True, autoincrement=True)
     guild_id = Column(BigInteger, ForeignKey('guilds.guild_id', ondelete='CASCADE'))
     raid_name = Column(String(255), nullable=False)
-    start_time = Column(DateTime, nullable=False)
-    end_time = Column(DateTime, nullable=False)
-    notify_time = Column(DateTime, nullable=True)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
+    notify_time = Column(DateTime(timezone=True), nullable=True)
     channel_id = Column(BigInteger, nullable=True)
-    created_at = Column(DateTime, default=lambda: utcnow_naive())
+    created_at = Column(DateTime(timezone=True), default=utcnow_aware)
     
     guild = relationship("Guild", back_populates="raids")
     participants = relationship("RaidParticipant", back_populates="raid", cascade="all, delete-orphan")
@@ -54,7 +63,7 @@ class RaidParticipant(Base):
     user_id = Column(BigInteger, nullable=False)
     username = Column(String(255), nullable=False)
     score = Column(Integer, default=0)
-    joined_at = Column(DateTime, default=lambda: utcnow_naive())
+    joined_at = Column(DateTime(timezone=True), default=utcnow_aware)
     
     raid = relationship("UnionRaid", back_populates="participants")
 
@@ -67,7 +76,7 @@ class RaidReport(Base):
     username = Column(String(255), nullable=False)
     difficulty = Column(String(32), nullable=False)  # 'normal' or 'hard'
     is_3t = Column(Integer, default=0)  # 1 = true, 0 = false
-    reported_at = Column(DateTime, default=lambda: utcnow_naive())
+    reported_at = Column(DateTime(timezone=True), default=utcnow_aware)
 
     raid = relationship("UnionRaid")
 
@@ -141,7 +150,7 @@ class UnionRaidCog(commands.Cog):
 
     async def resume_schedules(self):
         """起動時にDBから残っているレイドを読み、通知をスケジュールする"""
-        now = utcnow_naive()
+        now = utcnow_aware()
         async with async_session_factory() as session:
             result = await session.execute(
                 UnionRaid.__table__.select().where(
@@ -178,20 +187,18 @@ class UnionRaidCog(commands.Cog):
         class RaidStartModal(Modal, title="レイド開始設定"):
             def __init__(self):
                 super().__init__()
-                jst = timezone(timedelta(hours=9))
-                now_jst = datetime.now(jst)
-                default_time = now_jst.strftime("%Y-%m-%d %H:%M")
-                self.開始時刻 = TextInput(label="開始時刻 (YYYY-MM-DD HH:MM JST)", default=default_time, required=True)
+                now_local = localnow_aware()
+                default_time = now_local.strftime("%Y-%m-%d %H:%M")
+                self.開始時刻 = TextInput(label=f"開始時刻 (YYYY-MM-DD HH:MM {DEFAULT_TIMEZONE})", default=default_time, required=True)
                 self.add_item(self.開始時刻)
 
             async def on_submit(self, modal_interaction: discord.Interaction):
                 await modal_interaction.response.defer()
                 try:
                     start_text = self.開始時刻.value.strip()
-                    # parse as JST and convert to UTC for display/scheduling
-                    jst = timezone(timedelta(hours=9))
-                    start_time_jst = datetime.strptime(start_text, "%Y-%m-%d %H:%M").replace(tzinfo=jst)
-                    start_time_aware = start_time_jst.astimezone(timezone.utc)
+                    # parse as DEFAULT_TIMEZONE and convert to UTC for display/scheduling
+                    start_time_local = datetime.strptime(start_text, "%Y-%m-%d %H:%M").replace(tzinfo=DEFAULT_TIMEZONE)
+                    start_time_aware = start_time_local.astimezone(timezone.utc)
                     end_time_aware = start_time_aware + timedelta(hours=期間時間)
                     # store naive UTC datetimes in DB to match existing schema
                     start_time = start_time_aware.replace(tzinfo=None)
@@ -204,13 +211,13 @@ class UnionRaidCog(commands.Cog):
                             # upsert: race-safe insert (ON CONFLICT DO NOTHING)
                             stmt = pg_insert(Guild.__table__).values(
                                 guild_id=interaction.guild_id,
-                                created_at=utcnow_naive()
+                                created_at=utcnow_aware()
                             ).on_conflict_do_nothing(index_elements=['guild_id'])
                             await session.execute(stmt)
                             # ensure we have the guild object afterwards
                             guild = await session.get(Guild, interaction.guild_id)
 
-                        now = utcnow_naive()
+                        now = utcnow_aware()
                         q = await session.execute(
                             UnionRaid.__table__.select().where(
                                 (UnionRaid.guild_id == interaction.guild_id) & (UnionRaid.end_time > now)
@@ -333,7 +340,7 @@ class UnionRaidCog(commands.Cog):
                                         if existing:
                                             existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
                                             await session.execute(
-                                                RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_naive(), username=select_interaction.user.display_name)
+                                                RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_aware(), username=select_interaction.user.display_name)
                                             )
                                         else:
                                             report = RaidReport(raid_id=raid_id_ref, user_id=select_interaction.user.id, username=select_interaction.user.display_name, difficulty=difficulty, is_3t=1)
@@ -361,7 +368,7 @@ class UnionRaidCog(commands.Cog):
     async def raid_end(self, interaction: discord.Interaction):
         await interaction.response.defer(ephemeral=False)
         try:
-            now = utcnow_naive()
+            now = utcnow_aware()
             async with async_session_factory() as session:
                 q = await session.execute(
                     UnionRaid.__table__.select().where((UnionRaid.guild_id == interaction.guild_id) & (UnionRaid.end_time > now))

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -313,7 +313,7 @@ class UnionRaidCog(commands.Cog):
 
                     class ReportView(View):
                         def __init__(self, raid_id: int):
-                            super().__init__(timeout=None)
+                            super().__init__(timeout=60 * 60)
                             self.raid_id = raid_id
 
                         @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -352,6 +352,11 @@ class UnionRaidCog(commands.Cog):
                     timeout_seconds = (raid.end_time - utcnow_aware()).total_seconds()
                     view = ReportView(raid_id=raid.id, timeout_seconds=timeout_seconds)
                     await channel.send(embed=embed, view=view)
+                    async with async_session_factory() as session:
+                        await session.execute(
+                            UnionRaid.__table__.update().where(UnionRaid.id == raid.id).values(notify_time=None)
+                        )
+                        await session.commit()
                 except Exception as e:
                     logger.error(f"通知送信中にエラー: {e}")
             finally:

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -24,9 +24,6 @@ DEFAULT_TIMEZONE = timezone(timedelta(hours=DEFAULT_TIMEZONE_OFFSET))
 def utcnow_aware() -> datetime:
     return datetime.now(timezone.utc)
 
-def utcnow_naive() -> datetime:
-    return datetime.now(timezone.utc).replace(tzinfo=None)
-
 def localnow_aware() -> datetime:
     """デフォルトタイムゾーンでの現在時刻（aware）"""
     return datetime.now(DEFAULT_TIMEZONE)

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -312,8 +312,8 @@ class UnionRaidCog(commands.Cog):
                     embed.add_field(name="レイドID", value=f"`{raid.id}`")
 
                     class ReportView(View):
-                        def __init__(self, raid_id: int):
-                            super().__init__(timeout=60 * 60)
+                        def __init__(self, raid_id: int, timeout_seconds: float):
+                            super().__init__(timeout=timeout_seconds)
                             self.raid_id = raid_id
 
                         @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")
@@ -352,7 +352,8 @@ class UnionRaidCog(commands.Cog):
                             view.add_item(DifficultySelect())
                             await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
 
-                    view = ReportView(raid_id=raid.id)
+                    timeout_seconds = (raid.end_time - utcnow_aware()).total_seconds()
+                    view = ReportView(raid_id=raid.id, timeout_seconds=timeout_seconds)
                     await channel.send(embed=embed, view=view)
                 except Exception as e:
                     logger.error(f"通知送信中にエラー: {e}")

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -1,22 +1,34 @@
 import logging
 import asyncio
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import discord
 from discord import app_commands
 from discord.ext import commands
+from discord import ui
+from discord.ui import Modal, TextInput, View, Select, Button
+from typing import Optional, Dict
 from sqlalchemy import delete
 from database import async_session_factory, Base
 from sqlalchemy import Column, BigInteger, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)
+
+# ヘルパー: タイムゾーン情報付きの現在UTCと、DB保存用のナイーブUTCを返す
+def utcnow_aware() -> datetime:
+    return datetime.now(timezone.utc)
+
+def utcnow_naive() -> datetime:
+    return datetime.now(timezone.utc).replace(tzinfo=None)
 
 # データベースモデル
 class Guild(Base):
     __tablename__ = 'guilds'
     
     guild_id = Column(BigInteger, primary_key=True)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    created_at = Column(DateTime, default=lambda: utcnow_naive())
     
     raids = relationship("UnionRaid", back_populates="guild", cascade="all, delete-orphan")
 
@@ -28,7 +40,9 @@ class UnionRaid(Base):
     raid_name = Column(String(255), nullable=False)
     start_time = Column(DateTime, nullable=False)
     end_time = Column(DateTime, nullable=False)
-    created_at = Column(DateTime, default=datetime.utcnow)
+    notify_time = Column(DateTime, nullable=True)
+    channel_id = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime, default=lambda: utcnow_naive())
     
     guild = relationship("Guild", back_populates="raids")
     participants = relationship("RaidParticipant", back_populates="raid", cascade="all, delete-orphan")
@@ -41,9 +55,22 @@ class RaidParticipant(Base):
     user_id = Column(BigInteger, nullable=False)
     username = Column(String(255), nullable=False)
     score = Column(Integer, default=0)
-    joined_at = Column(DateTime, default=datetime.utcnow)
+    joined_at = Column(DateTime, default=lambda: utcnow_naive())
     
     raid = relationship("UnionRaid", back_populates="participants")
+
+class RaidReport(Base):
+    __tablename__ = 'raid_reports'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    raid_id = Column(Integer, ForeignKey('union_raids.id', ondelete='CASCADE'))
+    user_id = Column(BigInteger, nullable=False)
+    username = Column(String(255), nullable=False)
+    difficulty = Column(String(32), nullable=False)  # 'normal' or 'hard'
+    is_3t = Column(Integer, default=0)  # 1 = true, 0 = false
+    reported_at = Column(DateTime, default=lambda: utcnow_naive())
+
+    raid = relationship("UnionRaid")
 
 class NikkeUnionRaidBot(commands.Bot):
     def __init__(self):
@@ -61,7 +88,8 @@ class NikkeUnionRaidBot(commands.Bot):
     async def setup_hook(self):
         """Botの起動時に呼ばれる"""
         # コマンドを登録
-        await self.add_cog(UnionRaidCog(self))
+        cog = UnionRaidCog(self)
+        await self.add_cog(cog)
         
         # Discordとコマンドを同期
         logger.info("コマンドを同期しています...")
@@ -71,6 +99,11 @@ class NikkeUnionRaidBot(commands.Bot):
             logger.info("コマンドの同期が完了しました")
         except Exception as e:
             logger.warning(f"コマンド同期中にエラーが発生しました: {e}。Bot は継続して起動します。")
+        # resume schedules for pending raid notifications
+        try:
+            await cog.resume_schedules()
+        except Exception:
+            pass
     
     async def on_ready(self):
         """Botの準備が完了したときに呼ばれる"""
@@ -105,61 +138,270 @@ class NikkeUnionRaidBot(commands.Bot):
 class UnionRaidCog(commands.Cog):
     def __init__(self, bot: NikkeUnionRaidBot):
         self.bot = bot
+        self._scheduled_tasks: Dict[int, asyncio.Task] = {}
+
+    async def resume_schedules(self):
+        """起動時にDBから残っているレイドを読み、通知をスケジュールする"""
+        now = utcnow_naive()
+        async with async_session_factory() as session:
+            result = await session.execute(
+                UnionRaid.__table__.select().where(UnionRaid.notify_time != None)
+            )
+            rows = result.fetchall()
+            for row in rows:
+                # row is a SQLAlchemy RowMapping
+                data = dict(row._mapping)
+                # Build a lightweight raid-like object
+                class _R: pass
+                r = _R()
+                r.id = data.get('id')
+                r.guild_id = data.get('guild_id')
+                r.raid_name = data.get('raid_name')
+                r.start_time = data.get('start_time')
+                r.end_time = data.get('end_time')
+                r.notify_time = data.get('notify_time')
+                r.channel_id = data.get('channel_id')
+                if r.notify_time and r.notify_time > now:
+                    self._schedule_notification_task(r)
     
     @app_commands.command(name="レイド作成", description="新しいユニオンレイドを作成します")
     @app_commands.describe(
-        名前="レイドの名前",
         期間時間="レイドの期間（時間単位、デフォルト: 24時間）"
     )
     async def raid_create(
         self,
         interaction: discord.Interaction,
-        名前: str,
         期間時間: int = 24
     ):
-        """新しいユニオンレイドを作成"""
-        await interaction.response.defer()
-        
-        try:
-            async with async_session_factory() as session:
-                # サーバーが存在することを確認
-                guild = await session.get(Guild, interaction.guild_id)
-                if not guild:
-                    guild = Guild(guild_id=interaction.guild_id)
-                    session.add(guild)
-                    await session.flush()
-                
-                # レイドを作成
-                start_time = datetime.utcnow()
-                end_time = start_time + timedelta(hours=期間時間)
-                
-                raid = UnionRaid(
-                    guild_id=interaction.guild_id,
-                    raid_name=名前,
-                    start_time=start_time,
-                    end_time=end_time
-                )
-                session.add(raid)
-                await session.commit()
-                await session.refresh(raid)
-                
-                embed = discord.Embed(
-                    title="🎯 ユニオンレイドを作成しました",
-                    description=f"**{名前}**",
-                    color=discord.Color.green()
-                )
-                embed.add_field(name="レイドID", value=f"`{raid.id}`", inline=True)
-                embed.add_field(name="期間", value=f"{期間時間}時間", inline=True)
-                embed.add_field(name="開始時刻", value=f"<t:{int(start_time.timestamp())}:F>", inline=False)
-                embed.add_field(name="終了時刻", value=f"<t:{int(end_time.timestamp())}:F>", inline=False)
-                embed.set_footer(text=f"作成者: {interaction.user.display_name}")
-                
-                await interaction.followup.send(embed=embed)
-                logger.info(f"レイドを作成しました: {名前} (ID: {raid.id}) サーバー: {interaction.guild_id}")
+        """レイド作成: モーダルで開始時刻を受け取る（通知は開始時刻と同じ）"""
+        class RaidStartModal(Modal, title="レイド開始設定"):
+            def __init__(self):
+                super().__init__()
+                jst = timezone(timedelta(hours=9))
+                now_jst = datetime.now(jst)
+                default_time = now_jst.strftime("%Y-%m-%d %H:%M")
+                self.開始時刻 = TextInput(label="開始時刻 (YYYY-MM-DD HH:MM JST)", default=default_time, required=True)
+                self.add_item(self.開始時刻)
 
+            async def on_submit(self, modal_interaction: discord.Interaction):
+                await modal_interaction.response.defer()
+                try:
+                    start_text = self.開始時刻.value.strip()
+                    # parse as JST and convert to UTC for display/scheduling
+                    jst = timezone(timedelta(hours=9))
+                    start_time_jst = datetime.strptime(start_text, "%Y-%m-%d %H:%M").replace(tzinfo=jst)
+                    start_time_aware = start_time_jst.astimezone(timezone.utc)
+                    end_time_aware = start_time_aware + timedelta(hours=期間時間)
+                    # store naive UTC datetimes in DB to match existing schema
+                    start_time = start_time_aware.replace(tzinfo=None)
+                    end_time = end_time_aware.replace(tzinfo=None)
+                    notify_time = start_time
+
+                    async with async_session_factory() as session:
+                        guild = await session.get(Guild, interaction.guild_id)
+                        if not guild:
+                            # upsert: race-safe insert (ON CONFLICT DO NOTHING)
+                            stmt = pg_insert(Guild.__table__).values(
+                                guild_id=interaction.guild_id,
+                                created_at=utcnow_naive()
+                            ).on_conflict_do_nothing(index_elements=['guild_id'])
+                            await session.execute(stmt)
+                            # ensure we have the guild object afterwards
+                            guild = await session.get(Guild, interaction.guild_id)
+
+                        now = utcnow_naive()
+                        q = await session.execute(
+                            UnionRaid.__table__.select().where(
+                                (UnionRaid.guild_id == interaction.guild_id) & (UnionRaid.end_time > now)
+                            )
+                        )
+                        active = q.first()
+                        if active:
+                            await modal_interaction.followup.send("既に進行中のレイドが存在してるわ。先に終了させて頂戴。（/レイド終了）", ephemeral=True)
+                            return
+
+                        raid = UnionRaid(
+                            guild_id=interaction.guild_id,
+                            raid_name="ユニオンレイド",
+                            start_time=start_time,
+                            end_time=end_time,
+                            notify_time=notify_time,
+                            channel_id=interaction.channel_id
+                        )
+                        session.add(raid)
+                        await session.commit()
+                        await session.refresh(raid)
+
+                        embed = discord.Embed(title="🎯 ユニオンレイドを作成しました", description="**ユニオンレイド**", color=discord.Color.green())
+                        embed.add_field(name="レイドID", value=f"`{raid.id}`", inline=True)
+                        embed.add_field(name="期間", value=f"{期間時間}時間", inline=True)
+                        embed.add_field(name="開始時刻", value=f"<t:{int(start_time_aware.timestamp())}:F>", inline=False)
+                        embed.add_field(name="終了時刻", value=f"<t:{int(end_time_aware.timestamp())}:F>", inline=False)
+                        embed.set_footer(text=f"作成者: {interaction.user.display_name}")
+
+                        await modal_interaction.followup.send(embed=embed)
+
+                        try:
+                            cog: UnionRaidCog = interaction.client.get_cog('UnionRaidCog')
+                            if cog:
+                                class _R: pass
+                                r = _R()
+                                r.id = raid.id
+                                r.guild_id = raid.guild_id
+                                r.raid_name = "ユニオンレイド"
+                                # pass aware times for scheduling/display
+                                r.start_time = start_time_aware
+                                r.end_time = end_time_aware
+                                r.notify_time = start_time_aware
+                                r.channel_id = raid.channel_id
+                                cog._schedule_notification_task(r)
+                        except Exception:
+                            pass
+                except Exception as e:
+                    logger.exception(f"レイド作成モーダル処理中にエラー: {e}")
+                    try:
+                        await modal_interaction.followup.send(f"入力の解析に失敗しました: {e}", ephemeral=True)
+                    except discord.errors.NotFound:
+                        logger.exception(f"モーダル例外メッセージ送信失敗（Unknown interaction）")
+                    except Exception as se:
+                        logger.error(f"例外送信時にさらにエラー: {se}")
+
+        modal = RaidStartModal()
+        await interaction.response.send_modal(modal)
+
+    def _schedule_notification_task(self, raid: UnionRaid):
+        """レイドの通知タスクを作成して管理辞書に登録する"""
+        guild_id = raid.guild_id
+        if guild_id in self._scheduled_tasks:
+            return
+
+        async def _task():
+            # compute wait using timestamps to avoid aware/naive subtraction issues
+            if not raid.notify_time:
+                return
+            # convert notify_time to epoch (handle aware or naive)
+            if getattr(raid.notify_time, 'tzinfo', None) is None:
+                notify_ts = raid.notify_time.replace(tzinfo=timezone.utc).timestamp()
+            else:
+                notify_ts = raid.notify_time.timestamp()
+            now_ts = utcnow_aware().timestamp()
+            wait = notify_ts - now_ts
+            if wait > 0:
+                await asyncio.sleep(wait)
+            try:
+                channel = self.bot.get_channel(raid.channel_id)
+                if not channel:
+                    channel = await self.bot.fetch_channel(raid.channel_id)
+
+                embed = discord.Embed(title="📣 ユニオンレイド通知", description=f"人間、ユニオンレイドが始まったわ。", color=discord.Color.blue())
+                # ensure correct timestamp (make aware if naive)
+                if getattr(raid.start_time, 'tzinfo', None) is None:
+                    ts_dt = raid.start_time.replace(tzinfo=timezone.utc)
+                else:
+                    ts_dt = raid.start_time
+                embed.add_field(name="開始時刻", value=f"<t:{int(ts_dt.timestamp())}:F>")
+                embed.add_field(name="レイドID", value=f"`{raid.id}`")
+
+                class ReportView(View):
+                    def __init__(self, raid_id: int):
+                        super().__init__(timeout=None)
+                        self.raid_id = raid_id
+
+                    @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")
+                    async def report_button(self, interaction: discord.Interaction, button: Button):
+                        raid_id_ref = self.raid_id
+                        
+                        class DifficultySelect(Select):
+                            def __init__(self):
+                                options = [
+                                    discord.SelectOption(label="ノーマル", value="normal"),
+                                    discord.SelectOption(label="ハード", value="hard")
+                                ]
+                                super().__init__(placeholder="難易度を選択してください", options=options)
+                            
+                            async def callback(self, select_interaction: discord.Interaction):
+                                difficulty = self.values[0]
+                                async with async_session_factory() as session:
+                                    q = await session.execute(
+                                        RaidReport.__table__.select().where(
+                                            (RaidReport.raid_id == raid_id_ref) & (RaidReport.user_id == select_interaction.user.id) & (RaidReport.difficulty == difficulty)
+                                        )
+                                    )
+                                    existing = q.first()
+                                    if existing:
+                                        existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
+                                        await session.execute(
+                                            RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_naive(), username=select_interaction.user.display_name)
+                                        )
+                                    else:
+                                        report = RaidReport(raid_id=raid_id_ref, user_id=select_interaction.user.id, username=select_interaction.user.display_name, difficulty=difficulty, is_3t=1)
+                                        session.add(report)
+                                    await session.commit()
+                                await select_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
+                        
+                        view = View()
+                        view.add_item(DifficultySelect())
+                        await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
+
+                view = ReportView(raid_id=raid.id)
+                await channel.send(embed=embed, view=view)
+            except Exception as e:
+                logger.error(f"通知送信中にエラー: {e}")
+
+        task = asyncio.create_task(_task())
+        self._scheduled_tasks[guild_id] = task
+
+    @app_commands.command(name="レイド終了", description="進行中のレイドを終了し、3凸報告を集計します")
+    async def raid_end(self, interaction: discord.Interaction):
+        await interaction.response.defer(ephemeral=False)
+        try:
+            now = utcnow_naive()
+            async with async_session_factory() as session:
+                q = await session.execute(
+                    UnionRaid.__table__.select().where((UnionRaid.guild_id == interaction.guild_id) & (UnionRaid.end_time > now))
+                )
+                row = q.first()
+                if not row:
+                    await interaction.followup.send("進行中のレイドが見つかりません。", ephemeral=True)
+                    return
+                data = dict(row._mapping) if hasattr(row, '_mapping') else row
+                raid_id = data.get('id')
+                # 集計: ノーマルとハードで3凸のユーザーを取得
+                rq = await session.execute(
+                    RaidReport.__table__.select().where((RaidReport.raid_id == raid_id) & (RaidReport.is_3t == 1))
+                )
+                reports = rq.fetchall()
+                normal_users = []
+                hard_users = []
+                for rep in reports:
+                    repm = rep._mapping if hasattr(rep, '_mapping') else rep
+                    uname = repm.get('username')
+                    diff = repm.get('difficulty')
+                    if diff == 'normal':
+                        normal_users.append(uname)
+                    else:
+                        hard_users.append(uname)
+
+                embed = discord.Embed(title=f"レイド {data.get('raid_name')} の終了報告", color=discord.Color.gold())
+                embed.add_field(name="ノーマル 3凸", value=("\n".join(normal_users) if normal_users else "なし"), inline=False)
+                embed.add_field(name="ハード 3凸", value=("\n".join(hard_users) if hard_users else "なし"), inline=False)
+
+                # 終了処理: end_time を現在にセット
+                await session.execute(
+                    UnionRaid.__table__.update().where(UnionRaid.id == raid_id).values(end_time=now)
+                )
+                await session.commit()
+
+                # cancel scheduled task if any
+                gid = data.get('guild_id')
+                if gid in self._scheduled_tasks:
+                    t = self._scheduled_tasks.pop(gid)
+                    t.cancel()
+
+                await interaction.followup.send(embed=embed, content="人間、今回もおつかれさま。")
         except Exception as e:
-            logger.error(f"レイド作成時にエラーが発生しました: {e}")
-            await interaction.followup.send(f"❌ レイドの作成中にエラーが発生しました: {str(e)}", ephemeral=True)
+            logger.error(f"レイド終了時にエラー: {e}")
+            await interaction.followup.send(f"エラーが発生しました: {e}", ephemeral=True)
 
 async def setup(bot: NikkeUnionRaidBot):
     await bot.add_cog(UnionRaidCog(bot))

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -102,8 +102,8 @@ class NikkeUnionRaidBot(commands.Bot):
         # resume schedules for pending raid notifications
         try:
             await cog.resume_schedules()
-        except Exception:
-            pass
+        except Exception as e:
+            logger.error(f"スケジュール再開中にエラーが発生しました: {e}", exc_info=True)
     
     async def on_ready(self):
         """Botの準備が完了したときに呼ばれる"""
@@ -145,7 +145,9 @@ class UnionRaidCog(commands.Cog):
         now = utcnow_naive()
         async with async_session_factory() as session:
             result = await session.execute(
-                UnionRaid.__table__.select().where(UnionRaid.notify_time != None)
+                UnionRaid.__table__.select().where(
+                    (UnionRaid.notify_time != None) & (UnionRaid.end_time > now)
+                )
             )
             rows = result.fetchall()
             for row in rows:
@@ -276,77 +278,82 @@ class UnionRaidCog(commands.Cog):
             return
 
         async def _task():
-            # compute wait using timestamps to avoid aware/naive subtraction issues
-            if not raid.notify_time:
-                return
-            # convert notify_time to epoch (handle aware or naive)
-            if getattr(raid.notify_time, 'tzinfo', None) is None:
-                notify_ts = raid.notify_time.replace(tzinfo=timezone.utc).timestamp()
-            else:
-                notify_ts = raid.notify_time.timestamp()
-            now_ts = utcnow_aware().timestamp()
-            wait = notify_ts - now_ts
-            if wait > 0:
-                await asyncio.sleep(wait)
             try:
-                channel = self.bot.get_channel(raid.channel_id)
-                if not channel:
-                    channel = await self.bot.fetch_channel(raid.channel_id)
-
-                embed = discord.Embed(title="📣 ユニオンレイド通知", description=f"人間、ユニオンレイドが始まったわ。", color=discord.Color.blue())
-                # ensure correct timestamp (make aware if naive)
-                if getattr(raid.start_time, 'tzinfo', None) is None:
-                    ts_dt = raid.start_time.replace(tzinfo=timezone.utc)
+                # compute wait using timestamps to avoid aware/naive subtraction issues
+                if not raid.notify_time:
+                    return
+                # convert notify_time to epoch (handle aware or naive)
+                if getattr(raid.notify_time, 'tzinfo', None) is None:
+                    notify_ts = raid.notify_time.replace(tzinfo=timezone.utc).timestamp()
                 else:
-                    ts_dt = raid.start_time
-                embed.add_field(name="開始時刻", value=f"<t:{int(ts_dt.timestamp())}:F>")
-                embed.add_field(name="レイドID", value=f"`{raid.id}`")
+                    notify_ts = raid.notify_time.timestamp()
+                now_ts = utcnow_aware().timestamp()
+                wait = notify_ts - now_ts
+                if wait > 0:
+                    await asyncio.sleep(wait)
+                try:
+                    channel = self.bot.get_channel(raid.channel_id)
+                    if not channel:
+                        channel = await self.bot.fetch_channel(raid.channel_id)
 
-                class ReportView(View):
-                    def __init__(self, raid_id: int):
-                        super().__init__(timeout=None)
-                        self.raid_id = raid_id
+                    embed = discord.Embed(title="📣 ユニオンレイド通知", description=f"人間、ユニオンレイドが始まったわ。", color=discord.Color.blue())
+                    # ensure correct timestamp (make aware if naive)
+                    if getattr(raid.start_time, 'tzinfo', None) is None:
+                        ts_dt = raid.start_time.replace(tzinfo=timezone.utc)
+                    else:
+                        ts_dt = raid.start_time
+                    embed.add_field(name="開始時刻", value=f"<t:{int(ts_dt.timestamp())}:F>")
+                    embed.add_field(name="レイドID", value=f"`{raid.id}`")
 
-                    @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")
-                    async def report_button(self, interaction: discord.Interaction, button: Button):
-                        raid_id_ref = self.raid_id
-                        
-                        class DifficultySelect(Select):
-                            def __init__(self):
-                                options = [
-                                    discord.SelectOption(label="ノーマル", value="normal"),
-                                    discord.SelectOption(label="ハード", value="hard")
-                                ]
-                                super().__init__(placeholder="難易度を選択してください", options=options)
+                    class ReportView(View):
+                        def __init__(self, raid_id: int):
+                            super().__init__(timeout=None)
+                            self.raid_id = raid_id
+
+                        @ui.button(label="報告", style=discord.ButtonStyle.primary, custom_id="raid_report_button")
+                        async def report_button(self, interaction: discord.Interaction, button: Button):
+                            raid_id_ref = self.raid_id
                             
-                            async def callback(self, select_interaction: discord.Interaction):
-                                difficulty = self.values[0]
-                                async with async_session_factory() as session:
-                                    q = await session.execute(
-                                        RaidReport.__table__.select().where(
-                                            (RaidReport.raid_id == raid_id_ref) & (RaidReport.user_id == select_interaction.user.id) & (RaidReport.difficulty == difficulty)
+                            class DifficultySelect(Select):
+                                def __init__(self):
+                                    options = [
+                                        discord.SelectOption(label="ノーマル", value="normal"),
+                                        discord.SelectOption(label="ハード", value="hard")
+                                    ]
+                                    super().__init__(placeholder="難易度を選択してください", options=options)
+                                
+                                async def callback(self, select_interaction: discord.Interaction):
+                                    difficulty = self.values[0]
+                                    async with async_session_factory() as session:
+                                        q = await session.execute(
+                                            RaidReport.__table__.select().where(
+                                                (RaidReport.raid_id == raid_id_ref) & (RaidReport.user_id == select_interaction.user.id) & (RaidReport.difficulty == difficulty)
+                                            )
                                         )
-                                    )
-                                    existing = q.first()
-                                    if existing:
-                                        existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
-                                        await session.execute(
-                                            RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_naive(), username=select_interaction.user.display_name)
-                                        )
-                                    else:
-                                        report = RaidReport(raid_id=raid_id_ref, user_id=select_interaction.user.id, username=select_interaction.user.display_name, difficulty=difficulty, is_3t=1)
-                                        session.add(report)
-                                    await session.commit()
-                                await select_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
-                        
-                        view = View()
-                        view.add_item(DifficultySelect())
-                        await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
+                                        existing = q.first()
+                                        if existing:
+                                            existing_id = existing._mapping.get('id') if hasattr(existing, '_mapping') else existing.id
+                                            await session.execute(
+                                                RaidReport.__table__.update().where(RaidReport.id == existing_id).values(is_3t=1, reported_at=utcnow_naive(), username=select_interaction.user.display_name)
+                                            )
+                                        else:
+                                            report = RaidReport(raid_id=raid_id_ref, user_id=select_interaction.user.id, username=select_interaction.user.display_name, difficulty=difficulty, is_3t=1)
+                                            session.add(report)
+                                        await session.commit()
+                                    await select_interaction.response.send_message('報告を受け付けました。', ephemeral=True)
+                            
+                            view = View()
+                            view.add_item(DifficultySelect())
+                            await interaction.response.send_message('難易度を選択してください:', view=view, ephemeral=True)
 
-                view = ReportView(raid_id=raid.id)
-                await channel.send(embed=embed, view=view)
-            except Exception as e:
-                logger.error(f"通知送信中にエラー: {e}")
+                    view = ReportView(raid_id=raid.id)
+                    await channel.send(embed=embed, view=view)
+                except Exception as e:
+                    logger.error(f"通知送信中にエラー: {e}")
+            finally:
+                # Task completion時に必ず削除する
+                if guild_id in self._scheduled_tasks:
+                    self._scheduled_tasks.pop(guild_id, None)
 
         task = asyncio.create_task(_task())
         self._scheduled_tasks[guild_id] = task
@@ -386,9 +393,9 @@ class UnionRaidCog(commands.Cog):
                 embed.add_field(name="ノーマル 3凸", value=("\n".join(normal_users) if normal_users else "なし"), inline=False)
                 embed.add_field(name="ハード 3凸", value=("\n".join(hard_users) if hard_users else "なし"), inline=False)
 
-                # 終了処理: end_time を現在にセット
+                # 終了処理: end_time を現在にセット、notify_time をクリア
                 await session.execute(
-                    UnionRaid.__table__.update().where(UnionRaid.id == raid_id).values(end_time=now)
+                    UnionRaid.__table__.update().where(UnionRaid.id == raid_id).values(end_time=now, notify_time=None)
                 )
                 await session.commit()
 

--- a/src/discordbot.py
+++ b/src/discordbot.py
@@ -6,12 +6,11 @@ from discord import app_commands
 from discord.ext import commands
 from discord import ui
 from discord.ui import Modal, TextInput, View, Select, Button
-from typing import Optional, Dict
+from typing import Dict
 from sqlalchemy import delete
 from database import async_session_factory, Base
 from sqlalchemy import Column, BigInteger, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
-from sqlalchemy.exc import IntegrityError
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 
 logger = logging.getLogger(__name__)

--- a/src/main.py
+++ b/src/main.py
@@ -2,7 +2,7 @@ import os
 import asyncio
 import logging
 from dotenv import load_dotenv
-from discordbot import NikkeUnionRaidBot
+from bot import NikkeUnionRaidBot
 from database import init_db
 
 # Load environment variables

--- a/src/models.py
+++ b/src/models.py
@@ -1,6 +1,5 @@
 from sqlalchemy import Column, BigInteger, Integer, String, DateTime, ForeignKey
 from sqlalchemy.orm import relationship
-from sqlalchemy.dialects.postgresql import insert as pg_insert
 from database import Base
 
 class Guild(Base):

--- a/src/models.py
+++ b/src/models.py
@@ -6,7 +6,7 @@ class Guild(Base):
     __tablename__ = 'guilds'
     
     guild_id = Column(BigInteger, primary_key=True)
-    created_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    created_at = Column(DateTime(timezone=True))  # DB default now()
     
     raids = relationship("UnionRaid", back_populates="guild", cascade="all, delete-orphan")
 
@@ -20,7 +20,7 @@ class UnionRaid(Base):
     end_time = Column(DateTime(timezone=True), nullable=False)
     notify_time = Column(DateTime(timezone=True), nullable=True)
     channel_id = Column(BigInteger, nullable=True)
-    created_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    created_at = Column(DateTime(timezone=True))  # DB default now()
     
     guild = relationship("Guild", back_populates="raids")
     participants = relationship("RaidParticipant", back_populates="raid", cascade="all, delete-orphan")
@@ -33,7 +33,7 @@ class RaidParticipant(Base):
     user_id = Column(BigInteger, nullable=False)
     username = Column(String(255), nullable=False)
     score = Column(Integer, default=0)
-    joined_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    joined_at = Column(DateTime(timezone=True))  # DB default now()
     
     raid = relationship("UnionRaid", back_populates="participants")
 
@@ -46,6 +46,6 @@ class RaidReport(Base):
     username = Column(String(255), nullable=False)
     difficulty = Column(String(32), nullable=False)  # 'normal' or 'hard'
     is_3t = Column(Integer, default=0)  # 1 = true, 0 = false
-    reported_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    reported_at = Column(DateTime(timezone=True))  # DB default now()
 
     raid = relationship("UnionRaid")

--- a/src/models.py
+++ b/src/models.py
@@ -1,0 +1,52 @@
+from sqlalchemy import Column, BigInteger, Integer, String, DateTime, ForeignKey
+from sqlalchemy.orm import relationship
+from sqlalchemy.dialects.postgresql import insert as pg_insert
+from database import Base
+
+class Guild(Base):
+    __tablename__ = 'guilds'
+    
+    guild_id = Column(BigInteger, primary_key=True)
+    created_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    
+    raids = relationship("UnionRaid", back_populates="guild", cascade="all, delete-orphan")
+
+class UnionRaid(Base):
+    __tablename__ = 'union_raids'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    guild_id = Column(BigInteger, ForeignKey('guilds.guild_id', ondelete='CASCADE'))
+    raid_name = Column(String(255), nullable=False)
+    start_time = Column(DateTime(timezone=True), nullable=False)
+    end_time = Column(DateTime(timezone=True), nullable=False)
+    notify_time = Column(DateTime(timezone=True), nullable=True)
+    channel_id = Column(BigInteger, nullable=True)
+    created_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    
+    guild = relationship("Guild", back_populates="raids")
+    participants = relationship("RaidParticipant", back_populates="raid", cascade="all, delete-orphan")
+
+class RaidParticipant(Base):
+    __tablename__ = 'raid_participants'
+    
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    raid_id = Column(Integer, ForeignKey('union_raids.id', ondelete='CASCADE'))
+    user_id = Column(BigInteger, nullable=False)
+    username = Column(String(255), nullable=False)
+    score = Column(Integer, default=0)
+    joined_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+    
+    raid = relationship("UnionRaid", back_populates="participants")
+
+class RaidReport(Base):
+    __tablename__ = 'raid_reports'
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    raid_id = Column(Integer, ForeignKey('union_raids.id', ondelete='CASCADE'))
+    user_id = Column(BigInteger, nullable=False)
+    username = Column(String(255), nullable=False)
+    difficulty = Column(String(32), nullable=False)  # 'normal' or 'hard'
+    is_3t = Column(Integer, default=0)  # 1 = true, 0 = false
+    reported_at = Column(DateTime(timezone=True), default=None)  # Will be set in code
+
+    raid = relationship("UnionRaid")

--- a/src/utils.py
+++ b/src/utils.py
@@ -12,3 +12,10 @@ def utcnow_aware() -> datetime:
 def localnow_aware() -> datetime:
     """デフォルトタイムゾーンでの現在時刻（aware）"""
     return datetime.now(DEFAULT_TIMEZONE)
+
+def ensure_utc_aware(dt: datetime) -> datetime:
+    """datetime を UTC aware に統一する"""
+    if dt.tzinfo is None:
+        return dt.replace(tzinfo=timezone.utc)
+    else:
+        return dt.astimezone(timezone.utc)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,0 +1,14 @@
+import os
+from datetime import datetime, timedelta, timezone
+
+# デフォルトタイムゾーン設定（環境変数 DEFAULT_TIMEZONE で変更可能、デフォルト: JST）
+DEFAULT_TIMEZONE_OFFSET = int(os.getenv('DEFAULT_TIMEZONE_HOURS', '9'))
+DEFAULT_TIMEZONE = timezone(timedelta(hours=DEFAULT_TIMEZONE_OFFSET))
+
+# ヘルパー: タイムゾーン情報付きの現在UTCと、DB保存用のナイーブUTCを返す
+def utcnow_aware() -> datetime:
+    return datetime.now(timezone.utc)
+
+def localnow_aware() -> datetime:
+    """デフォルトタイムゾーンでの現在時刻（aware）"""
+    return datetime.now(DEFAULT_TIMEZONE)

--- a/src/utils.py
+++ b/src/utils.py
@@ -1,12 +1,12 @@
 import os
 from datetime import datetime, timedelta, timezone
 
-# デフォルトタイムゾーン設定（環境変数 DEFAULT_TIMEZONE で変更可能、デフォルト: JST）
+# デフォルトタイムゾーン設定（環境変数 DEFAULT_TIMEZONE_HOURS で変更可能、デフォルト: JST）
 DEFAULT_TIMEZONE_OFFSET = int(os.getenv('DEFAULT_TIMEZONE_HOURS', '9'))
 DEFAULT_TIMEZONE = timezone(timedelta(hours=DEFAULT_TIMEZONE_OFFSET))
 
-# ヘルパー: タイムゾーン情報付きの現在UTCと、DB保存用のナイーブUTCを返す
 def utcnow_aware() -> datetime:
+    """UTCの現在時刻（aware）"""
     return datetime.now(timezone.utc)
 
 def localnow_aware() -> datetime:


### PR DESCRIPTION
issue: #1 

## 概要
ユニオンレイド管理システムのデータベーススキーマとDiscord Bot機能を大幅に更新し、タイムゾーン対応とレイド報告機能を実装しました。

## 変更内容

### 📊 データベーススキーマの更新 (`init.sql`)
- **タイムスタンプの改善**: `TIMESTAMP` → `TIMESTAMPTZ` に変更し、タイムゾーン情報を保持
- **union_raids テーブルの拡張**:
  - `notify_time`: レイド通知のスケジュール時刻を追加
  - `channel_id`: 通知送信先チャンネルを追加
- **新テーブル `raid_reports` の追加**:
  - ユーザーのレイド難易度別報告（ノーマル/ハード）を記録
  - `is_3t` フラグで3凸完了をマーク
  - `reported_at` でレポート時刻を追跡

### 🤖 Discord Bot機能の拡張 (`src/discordbot.py`)

#### ヘルパー関数の追加
- `utcnow_aware()`: タイムゾーン情報付きUTC時刻
- `utcnow_naive()`: DB保存用のナイーブUTC時刻

#### データモデルの更新
- `Guild`: デフォルト値関数をアップデート
- `UnionRaid`: `notify_time` と `channel_id` フィールドを追加
- **新モデル `RaidReport`**: レイド報告の永続化に対応

#### 新しいコマンド機能
1. **レイド作成 (`/レイド作成`)**
   - モーダル入力で開始時刻（JST）を指定
   - JST → UTC の自動変換に対応
   - 進行中のレイドの重複作成防止
   - 作成時に自動的に通知タスクをスケジュール

2. **レイド終了 (`/レイド終了`)**
   - 3凸報告を集計して表示
   - ノーマル/ハード別に集計結果を表示
   - スケジュール済みタスクをキャンセル

#### バックグラウンド機能
- **`resume_schedules()`**: Bot起動時にDBから未実行の通知をロード
- **`_schedule_notification_task()`**: レイド開始時刻の通知をスケジュール
- **`_scheduled_tasks`**: アクティブなスケジュール管理

#### UI/UX 改善
- レイド報告にSelectメニューで難易度選択
- 3凸報告の簡素化（ボタン1クリック）
- タイムスタンプを Discordの`<t:...>` フォーマットで表示

## 📈 ファイル変更統計
```
docker-compose.yml |   4 +-
init.sql           |  23 +++-
src/discordbot.py  | 330 +++++++++++++++++++++++++++++++++++++++++++++++++-------
3 files changed, 305 insertions(+), 52 deletions(-)
```

## ✨ 主な改善点
- ✅ **タイムゾーン対応**: JST ↔ UTC の自動変換
- ✅ **永続的なスケジュール管理**: Bot再起動後もレイド通知を復旧
- ✅ **3凸報告の自動集計**: UI/UXの大幅改善
- ✅ **データ整合性**: PostgreSQL の制約とインデックスを活用
- ✅ **エラーハンドリング**: 例外処理を強化

## 🚀 テスト項目
- [ ] レイド作成時の JST/UTC 変換
- [ ] Bot再起動後の通知スケジュール復旧
- [ ] 3凸報告の正確な集計
- [ ] 進行中のレイド重複作成防止
- [ ] モーダル入力エラーハンドリング




<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes DB timestamp types and adds new tables/columns while also introducing async notification scheduling and interaction-driven DB writes, which can affect runtime behavior and data consistency.
> 
> **Overview**
> Adds **timezone-aware raid scheduling and reporting** across the DB schema and Discord bot.
> 
> `init.sql` migrates raid-related timestamps to `TIMESTAMPTZ`, extends `union_raids` with `notify_time`/`channel_id`, and introduces a new `raid_reports` table to persist per-user per-difficulty 3凸 reports.
> 
> `discordbot.py` updates SQLAlchemy models accordingly, changes `/レイド作成` to use a modal-based start time (defaulting to a configurable local timezone) and schedules a start notification that persists across restarts via `resume_schedules()`. The notification message now includes a UI button + difficulty select to record/update 3凸 reports, and `/レイド終了` ends the active raid, cancels any pending notification task, and posts an aggregated normal/hard report summary.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5fd8f5dacf79dca8e05621db00a9ec0388a7ae3d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->