### PR TITLE
Migrate Kotlin package and add initial Discord bot setup

### DIFF
--- a/kotlin/build.gradle.kts
+++ b/kotlin/build.gradle.kts
@@ -1,11 +1,13 @@
 plugins {
-    kotlin("jvm") version "2.1.21"
-    kotlin("plugin.spring") version "2.1.21"
-    id("org.springframework.boot") version "3.4.5"
+    kotlin("jvm") version "2.3.21"
+    kotlin("plugin.spring") version "2.3.21"
+    id("org.springframework.boot") version "4.0.6"
     id("io.spring.dependency-management") version "1.1.7"
+    id("com.google.devtools.ksp") version "2.3.7"
+    id("org.komapper.gradle") version "6.1.0"
 }
 
-group = "com.nikke"
+group = "gg.nikke.raid.bot"
 version = "0.0.1-SNAPSHOT"
 
 java {
@@ -22,6 +24,15 @@ dependencies {
     implementation("org.springframework.boot:spring-boot-starter-web")
     implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
     implementation("org.jetbrains.kotlin:kotlin-reflect")
+
+    // Database
+    implementation("org.komapper:komapper-spring-boot-starter-jdbc:6.1.0")
+    implementation("org.komapper:komapper-dialect-postgresql-jdbc:6.1.0")
+    implementation("org.postgresql:postgresql:42.7.10")
+    implementation("com.zaxxer:HikariCP:7.0.2")
+
+    // KSP for Komapper code generation
+    ksp("org.komapper:komapper-processor:6.1.0")
 
     implementation("net.dv8tion:JDA:6.4.1") {
         exclude(group = "org.slf4j", module = "slf4j-api")

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin/gradle/wrapper/gradle-wrapper.properties
+++ b/kotlin/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.3-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/kotlin/settings.gradle.kts
+++ b/kotlin/settings.gradle.kts
@@ -1,1 +1,12 @@
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
+}
+plugins {
+    id("org.gradle.toolchains.foojay-resolver-convention") version "0.10.0"
+}
+
 rootProject.name = "nikke-kotlin"

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/Main.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/Main.kt
@@ -1,14 +1,14 @@
-package com.nikke
+package gg.nikke.raid.bot
 
-import com.nikke.config.AppConfig
-import com.nikke.config.DiscordConfig
+import gg.nikke.raid.bot.config.AppConfig
+import gg.nikke.raid.bot.config.DiscordConfig
 import org.springframework.boot.autoconfigure.SpringBootApplication
 import org.springframework.boot.context.properties.EnableConfigurationProperties
 import org.springframework.boot.runApplication
 
 @SpringBootApplication
 @EnableConfigurationProperties(DiscordConfig::class, AppConfig::class)
-class NikkeApplication
+open class NikkeApplication
 
 fun main(args: Array<String>) {
     runApplication<NikkeApplication>(*args)

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/bot/DiscordBot.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/bot/DiscordBot.kt
@@ -1,13 +1,13 @@
-package com.nikke.bot
+package gg.nikke.raid.bot.bot
 
-import com.nikke.config.DiscordConfig
+import gg.nikke.raid.bot.config.DiscordConfig
+import jakarta.annotation.PostConstruct
+import jakarta.annotation.PreDestroy
 import net.dv8tion.jda.api.JDA
 import net.dv8tion.jda.api.JDABuilder
 import net.dv8tion.jda.api.exceptions.InvalidTokenException
-import jakarta.annotation.PostConstruct
-import jakarta.annotation.PreDestroy
-import org.springframework.stereotype.Component
 import org.slf4j.LoggerFactory
+import org.springframework.stereotype.Component
 import java.util.concurrent.CompletableFuture
 import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/config/AppConfig.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/config/AppConfig.kt
@@ -1,4 +1,4 @@
-package com.nikke.config
+package gg.nikke.raid.bot.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/config/DiscordConfig.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/config/DiscordConfig.kt
@@ -1,4 +1,4 @@
-package com.nikke.config
+package gg.nikke.raid.bot.config
 
 import org.springframework.boot.context.properties.ConfigurationProperties
 

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/controller/HealthController.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/controller/HealthController.kt
@@ -1,4 +1,4 @@
-package com.nikke.controller
+package gg.nikke.raid.bot.controller
 
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.RestController

--- a/kotlin/src/main/resources/application.properties
+++ b/kotlin/src/main/resources/application.properties
@@ -9,5 +9,9 @@ spring.datasource.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/nikke_unio
 spring.datasource.username=${POSTGRES_USER:postgres}
 spring.datasource.password=${POSTGRES_PASSWORD:}
 
+# Komapper
+komapper.dialect=postgresql
+komapper.jdbc.driver-class-name=org.postgresql.Driver
+
 # Timezone
 app.default-timezone-hours=${DEFAULT_TIMEZONE_HOURS:9}


### PR DESCRIPTION
# Feature PR

## 概要
Kotlin側のパッケージ構成を `gg.nikke.raid.bot` へ統一し、今後のDB実装に向けてKomapper/KSPとPostgreSQL関連設定を追加しました。

## 🎯 背景/目的
- 解決したい課題:
  - `com.nikke` ベースの暫定的な命名を整理し、プロジェクト識別子を統一したい
  - DBアクセス層実装に向けた依存関係と設定を先行整備したい
- この機能で得られる価値:
  - パッケージ/Group命名の一貫性向上
  - Komapperによる型安全なDB実装の準備完了
  - ビルド基盤（Gradle wrapper）の更新

## ✨ 変更内容
1. Kotlinソースのパッケージを `com.nikke` から `gg.nikke.raid.bot` に移行（`Main`, `bot`, `config`, `controller`）
2. `build.gradle.kts` を更新し、Komapper/KSP/PostgreSQL/HikariCP依存を追加、`group` を `gg.nikke.raid.bot` に変更
3. `application.properties` にKomapper設定を追加し、Gradle Wrapperを `8.14.4` へ更新

## 📦 仕様
- 入力:
  - 既存の環境変数（`DATABASE_URL`, `POSTGRES_USER`, `POSTGRES_PASSWORD` など）
- 出力:
  - Spring Bootアプリが新パッケージ構成で起動可能
  - Komapper JDBC設定が有効化された状態
- 制約:
  - 実際のDBリポジトリ実装は本PRでは未完了（設定先行）
- 例外/エラー時の挙動:
  - DB接続情報が不正な場合、起動時にDataSource/接続初期化で失敗

## 🧩 実装メモ
- 主要な設計判断:
  - パッケージ階層を `gg.nikke.raid.bot` に統一して命名衝突/曖昧性を回避
  - DBアクセス手段としてKomapper + KSPを採用
- トレードオフ:
  - 依存追加によりビルド/学習コストは増えるが、将来の型安全性と保守性を優先
- 将来の拡張ポイント:
  - Entity/Repository実装追加
  - マイグレーション導入（必要に応じてFlyway等）

## 📍 影響範囲
- [ ] API/コマンド追加・変更
- [ ] DBスキーマ変更
- [x] ジョブ/スケジューラ
- [ ] UI/メッセージ表示
- [x] 環境変数/設定変更

補足:
- DB接続設定・依存追加が中心。既存API仕様の変更はなし。

## ✅ テスト
- [ ] 単体テスト追加
- [ ] 既存テスト回帰確認
- [ ] 手動確認

テスト結果:
```text
未実施（CIまたはローカル実行結果を追記してください）