### PR TITLE
feat✨(util): 時刻操作用ユーティリティクラスを追加 (#21)

### DIFF
--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/util/TimeUtils.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/util/TimeUtils.kt
@@ -1,0 +1,48 @@
+package gg.nikke.raid.bot.util
+
+import java.time.Duration
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+/**
+ * 日付や時刻を操作するためのユーティリティクラス。
+ * オフセット日時（OffsetDateTime）を利用して、現在時刻の取得や変換、
+ * 時刻間の差分計算をサポートする。
+ */
+object TimeUtils {
+    /**
+     * 現在の時刻をUTCタイムゾーン（協定世界時）で返します。
+     *
+     * @return 現在のUTC時刻を表すOffsetDateTimeオブジェクト
+     */
+    fun utcNow(): OffsetDateTime = OffsetDateTime.now(ZoneOffset.UTC)
+
+    /**
+     * 指定された時間オフセットに基づいて現在の日時を取得します。
+     *
+     * @param offsetHours 時間オフセットを時間単位で指定します。例えば、日本標準時 (JST) の場合は 9 を指定します。
+     * @return 指定された時間オフセットの現在日時を表す OffsetDateTime インスタンス。
+     */
+    fun localNow(offsetHours: Int): OffsetDateTime =
+        OffsetDateTime.now(ZoneOffset.ofHours(offsetHours))
+
+    /**
+     * 指定された日時をUTCタイムゾーンに変換します。
+     * すでにUTCタイムゾーンの場合はそのまま返します。
+     *
+     * @param dt 変換対象の日時。任意のタイムゾーンが指定可能。
+     * @return UTCタイムゾーンに変換された日時。
+     */
+    fun ensureUtc(dt: OffsetDateTime): OffsetDateTime =
+        dt.withOffsetSameInstant(ZoneOffset.UTC)
+
+    /**
+     * 指定された現在時刻から目標時刻までの秒数を計算します。
+     *
+     * @param target 目標時刻を表すOffsetDateTimeオブジェクト。
+     * @param now 現在時刻を表すOffsetDateTimeオブジェクト。デフォルトはUTCの現在時刻。
+     * @return 現在時刻から目標時刻までの秒数。未来の目標時刻では正の値、過去の目標時刻では負の値が返されます。
+     */
+    fun secondsUntil(target: OffsetDateTime, now: OffsetDateTime = utcNow()): Long =
+        Duration.between(now, target).seconds
+}

--- a/kotlin/src/test/kotlin/gg/nikke/raid/bot/util/TimeUtilsTest.kt
+++ b/kotlin/src/test/kotlin/gg/nikke/raid/bot/util/TimeUtilsTest.kt
@@ -1,0 +1,68 @@
+package gg.nikke.raid.bot.util
+
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import java.time.OffsetDateTime
+import java.time.ZoneOffset
+
+class TimeUtilsTest {
+
+    @Test
+    fun `utcNow はUTCオフセットを返す`() {
+        val result = TimeUtils.utcNow()
+        assertEquals(ZoneOffset.UTC, result.offset)
+    }
+
+    @Test
+    fun `localNow はJSTオフセットを返す`() {
+        val result = TimeUtils.localNow(9)
+        assertEquals(ZoneOffset.ofHours(9), result.offset)
+    }
+
+    @Test
+    fun `ensureUtc はUTC入力をそのまま返す`() {
+        val utcTime = OffsetDateTime.parse("2024-01-01T12:00:00Z")
+        val result = TimeUtils.ensureUtc(utcTime)
+        assertEquals(ZoneOffset.UTC, result.offset)
+        assertEquals(utcTime.toInstant(), result.toInstant())
+    }
+
+    @Test
+    fun `ensureUtc はJST入力をUTCに変換する`() {
+        val jstTime = OffsetDateTime.parse("2024-01-01T21:00:00+09:00")
+        val result = TimeUtils.ensureUtc(jstTime)
+        assertEquals(ZoneOffset.UTC, result.offset)
+        assertEquals(OffsetDateTime.parse("2024-01-01T12:00:00Z").toInstant(), result.toInstant())
+    }
+
+    @Test
+    fun `secondsUntil は未来の時刻に対して正の値を返す`() {
+        val now = OffsetDateTime.parse("2024-01-01T12:00:00Z")
+        val target = now.plusSeconds(300)
+        val result = TimeUtils.secondsUntil(target, now)
+        assertEquals(300L, result)
+    }
+
+    @Test
+    fun `secondsUntil は過去の時刻に対して負の値を返す`() {
+        val now = OffsetDateTime.parse("2024-01-01T12:00:00Z")
+        val target = now.minusSeconds(60)
+        val result = TimeUtils.secondsUntil(target, now)
+        assertEquals(-60L, result)
+    }
+
+    @Test
+    fun `secondsUntil は同じ時刻に対してゼロを返す`() {
+        val now = OffsetDateTime.parse("2024-01-01T12:00:00Z")
+        val result = TimeUtils.secondsUntil(now, now)
+        assertEquals(0L, result)
+    }
+
+    @Test
+    fun `secondsUntil はタイムゾーンが異なっても同じ瞬間を正しく扱う`() {
+        val utcTime = OffsetDateTime.parse("2024-01-01T12:00:00Z")
+        val jstTime = OffsetDateTime.parse("2024-01-01T21:00:00+09:00")
+        val result = TimeUtils.secondsUntil(utcTime, jstTime)
+        assertEquals(0L, result)
+    }
+}


### PR DESCRIPTION
## 概要

- `TimeUtils` オブジェクト（`gg.nikke.raid.bot.util`）を新規作成
- Python の `utils.py` に実装されている時刻ユーティリティを Kotlin へ移植

## 変更内容

### `TimeUtils.kt`

| 関数 | Python対応 | 説明 |
|------|-----------|------|
| `utcNow()` | `utcnow_aware()` | UTC現在時刻を返す |
| `localNow(offsetHours)` | `localnow_aware()` | 指定オフセットの現在時刻を返す |
| `ensureUtc(dt)` | `ensure_utc_aware(dt)` | 任意オフセットのOffsetDateTimeをUTCに変換 |
| `secondsUntil(target, now)` | 通知待機秒数計算ロジック | 目標時刻までの秒数（負/ゼロ/正） |

`OffsetDateTime` は常にタイムゾーン情報を持つため、Pythonの aware/naive 相当の区別はなく、すべての入力が aware 相当として扱われることをテストで仕様化。

### `TimeUtilsTest.kt`

7件のユニットテストで受け入れ条件を検証。
- UTC/JST変換の正確性
- `ensureUtc` の UTC・非UTCオフセット入力両対応
- `secondsUntil` の負値・ゼロ・正値・タイムゾーン跨ぎ

## 関連 Issue

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)