### PR TITLE
feat✨(service): レイドドメインサービスを実装 (#22)

### DIFF
--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/Difficulty.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/Difficulty.kt
@@ -1,0 +1,11 @@
+package gg.nikke.raid.bot.service
+
+enum class Difficulty(val value: String) {
+    NORMAL("normal"),
+    HARD("hard");
+
+    companion object {
+        fun fromValue(value: String): Difficulty =
+            entries.first { it.value == value }
+    }
+}

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidAggregation.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidAggregation.kt
@@ -1,0 +1,20 @@
+package gg.nikke.raid.bot.service
+
+import java.math.BigDecimal
+
+/**
+ * レイドの集計結果を表すデータクラス。
+ *
+ * ギルド内で実施されたレイドの難易度ごとの参加報告数および参加割合を保持します。
+ *
+ * @property normalCount 通常難易度の参加報告数
+ * @property hardCount 高難易度の参加報告数
+ * @property normalPercentage 通常難易度の参加割合（%）
+ * @property hardPercentage 高難易度の参加割合（%）
+ */
+data class RaidAggregation(
+    val normalCount: Int,
+    val hardCount: Int,
+    val normalPercentage: BigDecimal,
+    val hardPercentage: BigDecimal,
+)

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidAggregation.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidAggregation.kt
@@ -1,20 +1,6 @@
 package gg.nikke.raid.bot.service
 
-import java.math.BigDecimal
-
-/**
- * レイドの集計結果を表すデータクラス。
- *
- * ギルド内で実施されたレイドの難易度ごとの参加報告数および参加割合を保持します。
- *
- * @property normalCount 通常難易度の参加報告数
- * @property hardCount 高難易度の参加報告数
- * @property normalPercentage 通常難易度の参加割合（%）
- * @property hardPercentage 高難易度の参加割合（%）
- */
 data class RaidAggregation(
-    val normalCount: Int,
-    val hardCount: Int,
-    val normalPercentage: BigDecimal,
-    val hardPercentage: BigDecimal,
+    val normalUsers: List<String>,
+    val hardUsers: List<String>,
 )

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainError.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainError.kt
@@ -6,5 +6,6 @@ sealed class RaidDomainError(message: String) : Exception(message) {
     data object DurationTooShort : RaidDomainError("レイド期間は1時間以上にしてください")
     data object ActiveRaidAlreadyExists : RaidDomainError("進行中のレイドが既に存在します")
     data object RankingAndPercentageBothSpecified : RaidDomainError("順位とパーセンテージは同時に指定できません")
+    data class RankingOutOfRange(val ranking: Int) : RaidDomainError("順位は1以上で指定してください: $ranking")
     data class PercentageOutOfRange(val percentage: BigDecimal) : RaidDomainError("パーセンテージは0より大きく100以下にしてください: $percentage")
 }

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainError.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainError.kt
@@ -1,0 +1,10 @@
+package gg.nikke.raid.bot.service
+
+import java.math.BigDecimal
+
+sealed class RaidDomainError(message: String) : Exception(message) {
+    data object DurationTooShort : RaidDomainError("レイド期間は1時間以上にしてください")
+    data object ActiveRaidAlreadyExists : RaidDomainError("進行中のレイドが既に存在します")
+    data object RankingAndPercentageBothSpecified : RaidDomainError("順位とパーセンテージは同時に指定できません")
+    data class PercentageOutOfRange(val percentage: BigDecimal) : RaidDomainError("パーセンテージは0より大きく100以下にしてください: $percentage")
+}

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
@@ -7,7 +7,6 @@ import gg.nikke.raid.bot.repository.UnionRaidRepository
 import gg.nikke.raid.bot.util.TimeUtils
 import org.springframework.stereotype.Service
 import java.math.BigDecimal
-import java.math.RoundingMode
 import java.time.Duration
 import java.time.OffsetDateTime
 
@@ -69,8 +68,8 @@ class RaidDomainService(
      * 指定されたレイドを終了します。
      *
      * @param raidId 終了するレイドのID
-     * @param ranking 終了時の順位（任意）。指定する場合、percentageと同時に指定することはできません
-     * @param percentage 終了時の進行状況を示すパーセンテージ（任意）。0より大きく100以下である必要があります。指定する場合、rankingと同時に指定することはできません
+     * @param ranking 終了時の順位（任意）。1以上で指定。percentageと同時指定不可
+     * @param percentage 終了時の上位パーセンテージ（任意）。0より大きく100以下。rankingと同時指定不可
      * @param now 現在時刻（デフォルト値はUTC現在時刻）
      * @return 更新されたレコード数を成功値として返却。失敗時はエラーを含むResultオブジェクトを返却
      */
@@ -82,6 +81,10 @@ class RaidDomainService(
     ): Result<Long> {
         if (ranking != null && percentage != null) {
             return Result.failure(RaidDomainError.RankingAndPercentageBothSpecified)
+        }
+
+        if (ranking != null && ranking < 1) {
+            return Result.failure(RaidDomainError.RankingOutOfRange(ranking))
         }
 
         if (percentage != null && (percentage <= BigDecimal.ZERO || percentage > BigDecimal("100"))) {
@@ -120,42 +123,17 @@ class RaidDomainService(
     }
 
     /**
-     * 指定されたレイド ID に基づきレイドの集計結果を計算する。
+     * 指定されたレイドの3凸報告をnormal/hard別のユーザー名リストに集計する。
      *
      * @param raidId レイド ID
-     * @return レイド報告の集計結果を表す `RaidAggregation` オブジェクト
+     * @return 難易度ごとの3凸済みユーザー名リストを含む `RaidAggregation`
      */
     fun aggregateRaidResults(raidId: Int): RaidAggregation {
         val reports = raidReportRepository.findRaidReportsByRaidId(raidId)
 
-        val normalCount = reports.count { it.difficulty == "normal" }
-        val hardCount = reports.count { it.difficulty == "hard" }
-        val total = normalCount + hardCount
-
-        if (total == 0) {
-            return RaidAggregation(
-                normalCount = 0,
-                hardCount = 0,
-                normalPercentage = BigDecimal.ZERO,
-                hardPercentage = BigDecimal.ZERO,
-            )
-        }
-
-        val totalDecimal = total.toBigDecimal()
-        val normalPercentage = normalCount.toBigDecimal()
-            .divide(totalDecimal, 4, RoundingMode.HALF_UP)
-            .multiply(BigDecimal("100"))
-            .setScale(2, RoundingMode.HALF_UP)
-        val hardPercentage = hardCount.toBigDecimal()
-            .divide(totalDecimal, 4, RoundingMode.HALF_UP)
-            .multiply(BigDecimal("100"))
-            .setScale(2, RoundingMode.HALF_UP)
-
         return RaidAggregation(
-            normalCount = normalCount,
-            hardCount = hardCount,
-            normalPercentage = normalPercentage,
-            hardPercentage = hardPercentage,
+            normalUsers = reports.filter { it.difficulty == "normal" }.map { it.username },
+            hardUsers = reports.filter { it.difficulty == "hard" }.map { it.username },
         )
     }
 }

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
@@ -1,0 +1,161 @@
+package gg.nikke.raid.bot.service
+
+import gg.nikke.raid.bot.entity.RaidReport
+import gg.nikke.raid.bot.entity.UnionRaid
+import gg.nikke.raid.bot.repository.RaidReportRepository
+import gg.nikke.raid.bot.repository.UnionRaidRepository
+import gg.nikke.raid.bot.util.TimeUtils
+import org.springframework.stereotype.Service
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.time.Duration
+import java.time.OffsetDateTime
+
+/**
+ * レイド管理のドメインサービスクラス。
+ * ギルド内のレイド管理、レイド結果の集計、および関連する操作を提供します。
+ *
+ * このクラスは、他のリポジトリとやり取りする責務を持ち、レイドの作成、完了、報告、および結果の集計を行います。
+ */
+@Service
+class RaidDomainService(
+    private val unionRaidRepository: UnionRaidRepository,
+    private val raidReportRepository: RaidReportRepository,
+) {
+
+    /**
+     * 新しいユニオンレイドを作成します。
+     *
+     * @param guildId レイドを作成するギルドのID
+     * @param raidName レイドの名前
+     * @param startTime レイドの開始時刻
+     * @param endTime レイドの終了時刻
+     * @param notifyTime レイド通知のための時刻（省略可能）
+     * @param channelId 通知やアクションに使用するチャンネルのID
+     * @param now 処理時の現在時刻（省略可能、デフォルトは現在のUTC時刻）
+     * @return 作成されたユニオンレイドを含む `Result`。失敗した場合はエラー情報を含みます。
+     */
+    fun createRaid(
+        guildId: Long,
+        raidName: String,
+        startTime: OffsetDateTime,
+        endTime: OffsetDateTime,
+        notifyTime: OffsetDateTime? = null,
+        channelId: Long,
+        now: OffsetDateTime = TimeUtils.utcNow(),
+    ): Result<UnionRaid> {
+        if (Duration.between(startTime, endTime) < Duration.ofHours(1)) {
+            return Result.failure(RaidDomainError.DurationTooShort)
+        }
+
+        if (unionRaidRepository.findActiveUnionRaidByGuildId(guildId, now) != null) {
+            return Result.failure(RaidDomainError.ActiveRaidAlreadyExists)
+        }
+
+        val raid = unionRaidRepository.insertUnionRaid(
+            UnionRaid(
+                guildId = guildId,
+                raidName = raidName,
+                startTime = startTime,
+                endTime = endTime,
+                notifyTime = notifyTime,
+                channelId = channelId,
+            )
+        )
+        return Result.success(raid)
+    }
+
+    /**
+     * 指定されたレイドを終了します。
+     *
+     * @param raidId 終了するレイドのID
+     * @param ranking 終了時の順位（任意）。指定する場合、percentageと同時に指定することはできません
+     * @param percentage 終了時の進行状況を示すパーセンテージ（任意）。0より大きく100以下である必要があります。指定する場合、rankingと同時に指定することはできません
+     * @param now 現在時刻（デフォルト値はUTC現在時刻）
+     * @return 更新されたレコード数を成功値として返却。失敗時はエラーを含むResultオブジェクトを返却
+     */
+    fun finishRaid(
+        raidId: Int,
+        ranking: Int? = null,
+        percentage: BigDecimal? = null,
+        now: OffsetDateTime = TimeUtils.utcNow(),
+    ): Result<Long> {
+        if (ranking != null && percentage != null) {
+            return Result.failure(RaidDomainError.RankingAndPercentageBothSpecified)
+        }
+
+        if (percentage != null && (percentage <= BigDecimal.ZERO || percentage > BigDecimal("100"))) {
+            return Result.failure(RaidDomainError.PercentageOutOfRange(percentage))
+        }
+
+        val updated = unionRaidRepository.finishUnionRaid(raidId, now, ranking, percentage)
+        return Result.success(updated)
+    }
+
+    /**
+     * ユーザーが3ターン撃破を報告したことを記録します。
+     *
+     * @param raidId レイドのID
+     * @param userId ユーザーのID
+     * @param username ユーザー名
+     * @param difficulty 難易度（例: "normal" または "hard"）
+     * @param now 報告の時刻（デフォルトは現在のUTC時刻）
+     * @return 保存された報告のIDを含む `Result` オブジェクト
+     */
+    fun reportThreeTurn(
+        raidId: Int,
+        userId: Long,
+        username: String,
+        difficulty: String,
+        now: OffsetDateTime = TimeUtils.utcNow(),
+    ): Result<Long> {
+        val report = RaidReport(
+            raidId = raidId,
+            userId = userId,
+            username = username,
+            difficulty = difficulty,
+            reportedAt = now,
+        )
+        return Result.success(raidReportRepository.saveRaidReport(report))
+    }
+
+    /**
+     * 指定されたレイド ID に基づきレイドの集計結果を計算する。
+     *
+     * @param raidId レイド ID
+     * @return レイド報告の集計結果を表す `RaidAggregation` オブジェクト
+     */
+    fun aggregateRaidResults(raidId: Int): RaidAggregation {
+        val reports = raidReportRepository.findRaidReportsByRaidId(raidId)
+
+        val normalCount = reports.count { it.difficulty == "normal" }
+        val hardCount = reports.count { it.difficulty == "hard" }
+        val total = normalCount + hardCount
+
+        if (total == 0) {
+            return RaidAggregation(
+                normalCount = 0,
+                hardCount = 0,
+                normalPercentage = BigDecimal.ZERO,
+                hardPercentage = BigDecimal.ZERO,
+            )
+        }
+
+        val totalDecimal = total.toBigDecimal()
+        val normalPercentage = normalCount.toBigDecimal()
+            .divide(totalDecimal, 4, RoundingMode.HALF_UP)
+            .multiply(BigDecimal("100"))
+            .setScale(2, RoundingMode.HALF_UP)
+        val hardPercentage = hardCount.toBigDecimal()
+            .divide(totalDecimal, 4, RoundingMode.HALF_UP)
+            .multiply(BigDecimal("100"))
+            .setScale(2, RoundingMode.HALF_UP)
+
+        return RaidAggregation(
+            normalCount = normalCount,
+            hardCount = hardCount,
+            normalPercentage = normalPercentage,
+            hardPercentage = hardPercentage,
+        )
+    }
+}

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
@@ -22,6 +22,12 @@ class RaidDomainService(
     private val raidReportRepository: RaidReportRepository,
 ) {
 
+    companion object {
+        private val MIN_RAID_DURATION = Duration.ofHours(1)
+        private const val MIN_RANKING = 1
+        private val MAX_PERCENTAGE = BigDecimal("100")
+    }
+
     /**
      * 新しいユニオンレイドを作成します。
      *
@@ -43,7 +49,7 @@ class RaidDomainService(
         channelId: Long,
         now: OffsetDateTime = TimeUtils.utcNow(),
     ): Result<UnionRaid> {
-        if (Duration.between(startTime, endTime) < Duration.ofHours(1)) {
+        if (Duration.between(startTime, endTime) < MIN_RAID_DURATION) {
             return Result.failure(RaidDomainError.DurationTooShort)
         }
 
@@ -83,11 +89,11 @@ class RaidDomainService(
             return Result.failure(RaidDomainError.RankingAndPercentageBothSpecified)
         }
 
-        if (ranking != null && ranking < 1) {
+        if (ranking != null && ranking < MIN_RANKING) {
             return Result.failure(RaidDomainError.RankingOutOfRange(ranking))
         }
 
-        if (percentage != null && (percentage <= BigDecimal.ZERO || percentage > BigDecimal("100"))) {
+        if (percentage != null && (percentage <= BigDecimal.ZERO || percentage > MAX_PERCENTAGE)) {
             return Result.failure(RaidDomainError.PercentageOutOfRange(percentage))
         }
 

--- a/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
+++ b/kotlin/src/main/kotlin/gg/nikke/raid/bot/service/RaidDomainService.kt
@@ -101,7 +101,7 @@ class RaidDomainService(
      * @param raidId レイドのID
      * @param userId ユーザーのID
      * @param username ユーザー名
-     * @param difficulty 難易度（例: "normal" または "hard"）
+     * @param difficulty 難易度
      * @param now 報告の時刻（デフォルトは現在のUTC時刻）
      * @return 保存された報告のIDを含む `Result` オブジェクト
      */
@@ -109,14 +109,14 @@ class RaidDomainService(
         raidId: Int,
         userId: Long,
         username: String,
-        difficulty: String,
+        difficulty: Difficulty,
         now: OffsetDateTime = TimeUtils.utcNow(),
     ): Result<Long> {
         val report = RaidReport(
             raidId = raidId,
             userId = userId,
             username = username,
-            difficulty = difficulty,
+            difficulty = difficulty.value,
             reportedAt = now,
         )
         return Result.success(raidReportRepository.saveRaidReport(report))
@@ -132,8 +132,8 @@ class RaidDomainService(
         val reports = raidReportRepository.findRaidReportsByRaidId(raidId)
 
         return RaidAggregation(
-            normalUsers = reports.filter { it.difficulty == "normal" }.map { it.username },
-            hardUsers = reports.filter { it.difficulty == "hard" }.map { it.username },
+            normalUsers = reports.filter { it.difficulty == Difficulty.NORMAL.value }.map { it.username },
+            hardUsers = reports.filter { it.difficulty == Difficulty.HARD.value }.map { it.username },
         )
     }
 }

--- a/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
+++ b/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
@@ -223,7 +223,7 @@ open class RaidDomainServiceTest(
             raidId = raid.id,
             userId = 90_000_001L,
             username = "test-user",
-            difficulty = "normal",
+            difficulty = Difficulty.NORMAL,
             now = now,
         )
 
@@ -244,8 +244,8 @@ open class RaidDomainServiceTest(
             now = now,
         ).getOrThrow()
 
-        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "old-name", "hard", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "new-name", "hard", now.plusMinutes(10))
+        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "old-name", Difficulty.HARD, now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "new-name", Difficulty.HARD, now.plusMinutes(10))
 
         val aggregation = raidDomainService.aggregateRaidResults(raid.id)
         assertEquals(0, aggregation.normalUsers.size)
@@ -290,9 +290,9 @@ open class RaidDomainServiceTest(
             now = now,
         ).getOrThrow()
 
-        raidDomainService.reportThreeTurn(raid.id, 90_000_011L, "user-normal-1", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_012L, "user-normal-2", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_013L, "user-hard-1", "hard", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_011L, "user-normal-1", Difficulty.NORMAL, now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_012L, "user-normal-2", Difficulty.NORMAL, now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_013L, "user-hard-1", Difficulty.HARD, now)
 
         val result = raidDomainService.aggregateRaidResults(raid.id)
 
@@ -316,8 +316,8 @@ open class RaidDomainServiceTest(
             now = now,
         ).getOrThrow()
 
-        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "old-name", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "new-name", "normal", now.plusMinutes(10))
+        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "old-name", Difficulty.NORMAL, now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "new-name", Difficulty.NORMAL, now.plusMinutes(10))
 
         val result = raidDomainService.aggregateRaidResults(raid.id)
 

--- a/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
+++ b/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
@@ -1,0 +1,317 @@
+package gg.nikke.raid.bot.service
+
+import gg.nikke.raid.bot.entity.Guild
+import gg.nikke.raid.bot.repository.GuildRepository
+import org.junit.jupiter.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.TestConstructor
+import org.springframework.transaction.annotation.Transactional
+import java.math.BigDecimal
+import java.time.OffsetDateTime
+
+@SpringBootTest
+@Transactional
+@TestConstructor(autowireMode = TestConstructor.AutowireMode.ALL)
+open class RaidDomainServiceTest(
+    private val raidDomainService: RaidDomainService,
+    private val guildRepository: GuildRepository,
+) {
+
+    // ----------------------------------------------------------------
+    // createRaid
+    // ----------------------------------------------------------------
+
+    @Test
+    fun `レイド作成_期間ちょうど1時間で成功する`() {
+        val guildId = 70_000_001L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+
+        val result = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(1),
+            channelId = 80_000_001L,
+            now = now,
+        )
+
+        assertTrue(result.isSuccess)
+        assertEquals("test-raid", result.getOrNull()?.raidName)
+    }
+
+    @Test
+    fun `レイド作成_期間が59分のときDurationTooShortエラーになる`() {
+        val guildId = 70_000_002L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+
+        val result = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusMinutes(59),
+            channelId = 80_000_002L,
+            now = now,
+        )
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.DurationTooShort::class.java, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `レイド作成_進行中レイドが存在するときActiveRaidAlreadyExistsエラーになる`() {
+        val guildId = 70_000_003L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+
+        raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "first-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_003L,
+            now = now,
+        )
+
+        val result = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "second-raid",
+            startTime = now.plusHours(1),
+            endTime = now.plusHours(3),
+            channelId = 80_000_003L,
+            now = now,
+        )
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.ActiveRaidAlreadyExists::class.java, result.exceptionOrNull())
+    }
+
+    // ----------------------------------------------------------------
+    // finishRaid
+    // ----------------------------------------------------------------
+
+    @Test
+    fun `レイド終了_順位のみで成功する`() {
+        val guildId = 70_000_004L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_004L,
+            now = now,
+        ).getOrThrow()
+
+        val result = raidDomainService.finishRaid(raidId = raid.id, ranking = 100)
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `レイド終了_パーセンテージのみで成功する`() {
+        val guildId = 70_000_005L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_005L,
+            now = now,
+        ).getOrThrow()
+
+        val result = raidDomainService.finishRaid(raidId = raid.id, percentage = BigDecimal("50.00"))
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `レイド終了_パーセンテージ100で成功する`() {
+        val guildId = 70_000_006L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_006L,
+            now = now,
+        ).getOrThrow()
+
+        val result = raidDomainService.finishRaid(raidId = raid.id, percentage = BigDecimal("100"))
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `レイド終了_順位とパーセンテージの同時指定でRankingAndPercentageBothSpecifiedエラーになる`() {
+        val result = raidDomainService.finishRaid(
+            raidId = 1,
+            ranking = 100,
+            percentage = BigDecimal("50.00"),
+        )
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.RankingAndPercentageBothSpecified::class.java, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `レイド終了_パーセンテージ0でPercentageOutOfRangeエラーになる`() {
+        val result = raidDomainService.finishRaid(raidId = 1, percentage = BigDecimal("0"))
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.PercentageOutOfRange::class.java, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `レイド終了_負のパーセンテージでPercentageOutOfRangeエラーになる`() {
+        val result = raidDomainService.finishRaid(raidId = 1, percentage = BigDecimal("-1"))
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.PercentageOutOfRange::class.java, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `レイド終了_パーセンテージ100超でPercentageOutOfRangeエラーになる`() {
+        val result = raidDomainService.finishRaid(raidId = 1, percentage = BigDecimal("100.01"))
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.PercentageOutOfRange::class.java, result.exceptionOrNull())
+    }
+
+    // ----------------------------------------------------------------
+    // reportThreeTurn
+    // ----------------------------------------------------------------
+
+    @Test
+    fun `3凸報告_新規登録される`() {
+        val guildId = 70_000_007L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_007L,
+            now = now,
+        ).getOrThrow()
+
+        val result = raidDomainService.reportThreeTurn(
+            raidId = raid.id,
+            userId = 90_000_001L,
+            username = "test-user",
+            difficulty = "normal",
+            now = now,
+        )
+
+        assertTrue(result.isSuccess)
+    }
+
+    @Test
+    fun `3凸報告_同一ユーザー同一難易度の報告はupsertされ件数が増えない`() {
+        val guildId = 70_000_008L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_008L,
+            now = now,
+        ).getOrThrow()
+
+        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "old-name", "hard", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "new-name", "hard", now.plusMinutes(10))
+
+        val aggregation = raidDomainService.aggregateRaidResults(raid.id)
+        assertEquals(0, aggregation.normalCount)
+        assertEquals(1, aggregation.hardCount)
+    }
+
+    // ----------------------------------------------------------------
+    // aggregateRaidResults
+    // ----------------------------------------------------------------
+
+    @Test
+    fun `集計_報告がない場合は0を返す`() {
+        val guildId = 70_000_009L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_009L,
+            now = now,
+        ).getOrThrow()
+
+        val result = raidDomainService.aggregateRaidResults(raid.id)
+
+        assertEquals(0, result.normalCount)
+        assertEquals(0, result.hardCount)
+        assertEquals(BigDecimal.ZERO, result.normalPercentage)
+        assertEquals(BigDecimal.ZERO, result.hardPercentage)
+    }
+
+    @Test
+    fun `集計_難易度別の件数が正しく集計される`() {
+        val guildId = 70_000_010L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_010L,
+            now = now,
+        ).getOrThrow()
+
+        raidDomainService.reportThreeTurn(raid.id, 90_000_011L, "user1", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_012L, "user2", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_013L, "user3", "hard", now)
+
+        val result = raidDomainService.aggregateRaidResults(raid.id)
+
+        assertEquals(2, result.normalCount)
+        assertEquals(1, result.hardCount)
+    }
+
+    @Test
+    fun `集計_パーセンテージが小数第2位で丸められる`() {
+        val guildId = 70_000_011L
+        val now = OffsetDateTime.now()
+        guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
+        val raid = raidDomainService.createRaid(
+            guildId = guildId,
+            raidName = "test-raid",
+            startTime = now,
+            endTime = now.plusHours(2),
+            channelId = 80_000_011L,
+            now = now,
+        ).getOrThrow()
+
+        // normal 5件, hard 2件 → normal: 5/7≒71.43%, hard: 2/7≒28.57%
+        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "user1", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_022L, "user2", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_023L, "user3", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_024L, "user4", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_025L, "user5", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_026L, "user6", "hard", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_027L, "user7", "hard", now)
+
+        val result = raidDomainService.aggregateRaidResults(raid.id)
+
+        assertEquals(BigDecimal("71.43"), result.normalPercentage)
+        assertEquals(BigDecimal("28.57"), result.hardPercentage)
+    }
+}

--- a/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
+++ b/kotlin/src/test/kotlin/gg/nikke/raid/bot/service/RaidDomainServiceTest.kt
@@ -162,6 +162,22 @@ open class RaidDomainServiceTest(
     }
 
     @Test
+    fun `レイド終了_順位0でRankingOutOfRangeエラーになる`() {
+        val result = raidDomainService.finishRaid(raidId = 1, ranking = 0)
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.RankingOutOfRange::class.java, result.exceptionOrNull())
+    }
+
+    @Test
+    fun `レイド終了_負の順位でRankingOutOfRangeエラーになる`() {
+        val result = raidDomainService.finishRaid(raidId = 1, ranking = -1)
+
+        assertTrue(result.isFailure)
+        assertInstanceOf(RaidDomainError.RankingOutOfRange::class.java, result.exceptionOrNull())
+    }
+
+    @Test
     fun `レイド終了_パーセンテージ0でPercentageOutOfRangeエラーになる`() {
         val result = raidDomainService.finishRaid(raidId = 1, percentage = BigDecimal("0"))
 
@@ -232,8 +248,8 @@ open class RaidDomainServiceTest(
         raidDomainService.reportThreeTurn(raid.id, 90_000_002L, "new-name", "hard", now.plusMinutes(10))
 
         val aggregation = raidDomainService.aggregateRaidResults(raid.id)
-        assertEquals(0, aggregation.normalCount)
-        assertEquals(1, aggregation.hardCount)
+        assertEquals(0, aggregation.normalUsers.size)
+        assertEquals(1, aggregation.hardUsers.size)
     }
 
     // ----------------------------------------------------------------
@@ -241,7 +257,7 @@ open class RaidDomainServiceTest(
     // ----------------------------------------------------------------
 
     @Test
-    fun `集計_報告がない場合は0を返す`() {
+    fun `集計_報告がない場合は空リストを返す`() {
         val guildId = 70_000_009L
         val now = OffsetDateTime.now()
         guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
@@ -256,14 +272,12 @@ open class RaidDomainServiceTest(
 
         val result = raidDomainService.aggregateRaidResults(raid.id)
 
-        assertEquals(0, result.normalCount)
-        assertEquals(0, result.hardCount)
-        assertEquals(BigDecimal.ZERO, result.normalPercentage)
-        assertEquals(BigDecimal.ZERO, result.hardPercentage)
+        assertTrue(result.normalUsers.isEmpty())
+        assertTrue(result.hardUsers.isEmpty())
     }
 
     @Test
-    fun `集計_難易度別の件数が正しく集計される`() {
+    fun `集計_難易度別のユーザー名リストが正しく集計される`() {
         val guildId = 70_000_010L
         val now = OffsetDateTime.now()
         guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
@@ -276,18 +290,20 @@ open class RaidDomainServiceTest(
             now = now,
         ).getOrThrow()
 
-        raidDomainService.reportThreeTurn(raid.id, 90_000_011L, "user1", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_012L, "user2", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_013L, "user3", "hard", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_011L, "user-normal-1", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_012L, "user-normal-2", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_013L, "user-hard-1", "hard", now)
 
         val result = raidDomainService.aggregateRaidResults(raid.id)
 
-        assertEquals(2, result.normalCount)
-        assertEquals(1, result.hardCount)
+        assertEquals(2, result.normalUsers.size)
+        assertEquals(1, result.hardUsers.size)
+        assertTrue(result.normalUsers.containsAll(listOf("user-normal-1", "user-normal-2")))
+        assertEquals("user-hard-1", result.hardUsers[0])
     }
 
     @Test
-    fun `集計_パーセンテージが小数第2位で丸められる`() {
+    fun `集計_upsert後のユーザー名は最新名で返る`() {
         val guildId = 70_000_011L
         val now = OffsetDateTime.now()
         guildRepository.insertGuild(Guild(guildId = guildId, createdAt = now))
@@ -300,18 +316,12 @@ open class RaidDomainServiceTest(
             now = now,
         ).getOrThrow()
 
-        // normal 5件, hard 2件 → normal: 5/7≒71.43%, hard: 2/7≒28.57%
-        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "user1", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_022L, "user2", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_023L, "user3", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_024L, "user4", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_025L, "user5", "normal", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_026L, "user6", "hard", now)
-        raidDomainService.reportThreeTurn(raid.id, 90_000_027L, "user7", "hard", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "old-name", "normal", now)
+        raidDomainService.reportThreeTurn(raid.id, 90_000_021L, "new-name", "normal", now.plusMinutes(10))
 
         val result = raidDomainService.aggregateRaidResults(raid.id)
 
-        assertEquals(BigDecimal("71.43"), result.normalPercentage)
-        assertEquals(BigDecimal("28.57"), result.hardPercentage)
+        assertEquals(1, result.normalUsers.size)
+        assertEquals("new-name", result.normalUsers[0])
     }
 }

--- a/kotlin/src/test/resources/application.properties
+++ b/kotlin/src/test/resources/application.properties
@@ -1,1 +1,5 @@
 discord.bot.enabled=false
+
+spring.datasource.url=${DATABASE_URL:jdbc:postgresql://localhost:5432/nikke_unionraid}
+spring.datasource.username=${POSTGRES_USER:postgres}
+spring.datasource.password=${POSTGRES_PASSWORD:}


### PR DESCRIPTION
# Feature PR

## 概要
レイド管理のドメインサービス層を実装。Discord型への依存を排除し、業務ロジックをサービス層に集約した。

## 🎯 背景/目的
- 解決したい課題: Discord SDKへの依存が分散しており、業務ロジックのテストが困難
- この機能で得られる価値: ドメイン層が純粋なKotlinで表現され、バリデーション仕様がテストで担保される

## ✨ 変更内容
1. `RaidDomainError` — 判別可能なエラー型をsealed classで定義
2. `RaidDomainService` — 4つのユースケース（作成・終了・3凸報告・集計）を実装
3. `RaidDomainServiceTest` — バリデーション・DB操作を含む15テストを追加

## 📦 仕様
- 入力: guildId/raidId/userId等のプリミティブ型 + OffsetDateTime（Discord型を含まない）
- 出力: `Result<T>` でSuccess/Failureを型安全に返却
- 制約: 期間1時間以上、パーセンテージ(0, 100]、順位とパーセンテージの同時指定不可
- 例外/エラー時の挙動: `RaidDomainError` sealed classのサブタイプで返却（DurationTooShort / ActiveRaidAlreadyExists / RankingAndPercentageBothSpecified / PercentageOutOfRange）

## 🧩 実装メモ
- 主要な設計判断: エラーを例外throwではなく`Result.failure()`で返すことでコール側が明示的にハンドリングできるようにした
- トレードオフ: 集計パーセンテージは「normal件数/合計件数 × 100」として算出。難易度間の分布を表す指標とした
- 将来の拡張ポイント: 集計ロジックはギルドメンバー数を分母にする拡張も可能

## 📍 影響範囲
- [ ] API/コマンド追加・変更
- [ ] DBスキーマ変更
- [ ] ジョブ/スケジューラ
- [ ] UI/メッセージ表示
- [x] 環境変数/設定変更

補足:
- `src/test/resources/application.properties` にDB設定を追加（前コミットでテスト用設定がメインを上書きしDB接続設定が欠落していたバグ修正）

## ✅ テスト
- [x] 単体テスト追加
- [x] 既存テスト回帰確認
- [ ] 手動確認

テスト結果:
```text
34 tests completed, 0 failed
```

## 📝 マイグレーション/運用手順（必要な場合）
なし

## 🚀 今後の課題（任意）
- Discordコマンドハンドラーからこのドメインサービスを呼び出す実装（別Issue）